### PR TITLE
Updated cabal dependencies so project will build

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -38,7 +38,7 @@ Library
                        containers,
                        extensible-exceptions,
                        safecopy >= 0.6,
-                       stm,
+                       stm >= 2.4,
                        directory,
                        filepath,
                        mtl,


### PR DESCRIPTION
TQueue requires stm-2.4 and the Lazy.fromStrict workaround in Log.hs requires bytestring-10.*
