### PR TITLE
do not proceed with parsing after ccGetSome retuns empty ByteString

### DIFF
--- a/src/Data/Acid/Remote.hs
+++ b/src/Data/Acid/Remote.hs
@@ -213,10 +213,6 @@ sharedSecretPerform pw cc =
      using a socket file. To control access, you can set the permissions of
      the parent directory which contains the socket file.
 
-     The message @SerializeError "too few bytes\nFrom:\tdemandInput\n\n"@ is
-     displayed on the standard error channel of the server whenever a
-     client disconnects.
-
      see also: 'openRemoteState' and 'sharedSecretCheck'.
  -}
 acidServer :: SafeCopy st =>
@@ -312,7 +308,10 @@ process CommChannel{..} acidState
           = case inp of
               Fail msg      -> throwIO (SerializeError msg)
               Partial cont  -> do bs <- ccGetSome 1024
-                                  worker chan (cont bs)
+                                  if Strict.null bs then
+                                     return ()
+                                  else
+                                     worker chan (cont bs)
               Done cmd rest -> do processCommand chan cmd; worker chan (runGetPartial get rest)
         processCommand chan cmd =
           case cmd of


### PR DESCRIPTION
This patch is intended to fix #11. The motivation for the change
is that underlying implementation for ccGetSome is a recv/read call
which should return empty result only in case of exception. Last
assumption may not hold for arbitrary ccGetSome implementation.
