### PR TITLE
Generate newtype declaration for single argument event constructors

### DIFF
--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -209,7 +209,9 @@ makeEventHandler eventName eventType
 --  deriving (Typeable)
 makeEventDataType eventName eventType
     = do let con = normalC eventStructName [ strictType notStrict (return arg) | arg <- args ]
-         dataD (return []) eventStructName tyvars [con] [''Typeable]
+         case args of
+          [_] -> newtypeD (return []) eventStructName tyvars con [''Typeable]
+          _   -> dataD (return []) eventStructName tyvars [con] [''Typeable]
     where (tyvars, _cxt, args, _stateType, _resultType, _isUpdate) = analyseType eventName eventType
           eventStructName = mkName (structName (nameBase eventName))
           structName [] = []


### PR DESCRIPTION
Since the fields of the generated constructors are not-strict by default this does not have any impact on semantics but lets the compiler optimize further by eliminating boxing of constructor field. Like one would use newtype anyways if there is only one constructor with one field. 
