### PR TITLE
Compatibility for ghc 7.10

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -1,5 +1,5 @@
 Name:                acid-state
-Version:             0.12.3
+Version:             0.12.4
 Synopsis:            Add ACID guarantees to any serializable Haskell data structure.
 Description:         Use regular Haskell data structures as your database and get stronger ACID guarantees than most RDBMS offer.
 Homepage:            http://acid-state.seize.it/
@@ -74,7 +74,7 @@ benchmark loading-benchmark
     directory,
     system-fileio == 0.3.*,
     system-filepath,
-    criterion == 0.8.*,
+    criterion >= 0.8 && < 1.1,
     mtl,
     base,
     acid-state

--- a/benchmarks/loading/Benchmark/Model.hs
+++ b/benchmarks/loading/Benchmark/Model.hs
@@ -1,6 +1,6 @@
 module Benchmark.Model where
 
-import Benchmark.Prelude
+import Benchmark.Prelude hiding (insert)
 import qualified Data.Acid as Acid
 
 
@@ -11,5 +11,3 @@ insert :: [[Int]] -> Acid.Update Model ()
 insert = modify . (:)
 
 Acid.makeAcidic ''Model ['insert]
-
-

--- a/src/Data/Acid/Core.hs
+++ b/src/Data/Acid/Core.hs
@@ -59,9 +59,13 @@ import Data.Typeable.Internal             ( TypeRep (..), tyConModule )
 -- of base. We could do something better, but happstack-state is
 -- end-of-life anyway.
 showQualifiedTypeRep :: TypeRep -> String
-showQualifiedTypeRep tr =
-    let (TypeRep _f con _rep) = tr
-    in tyConModule con ++ "." ++ show tr
+showQualifiedTypeRep tr = tyConModule con ++ "." ++ show tr
+  where con = extractTypeRepCon tr
+#if MIN_VERSION_base(4,8,0)
+        extractTypeRepCon (TypeRep _ c _ _) = c
+#else
+        extractTypeRepCon (TypeRep _ c _) = c
+#endif
 
 #else
 

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -141,8 +141,12 @@ eventCxts targetStateType targetTyVars eventName eventType =
     where
       -- | rename the type variables in a Pred
       unify :: [(Name, Name)] -> Pred -> Pred
+#if MIN_VERSION_template_haskell(2,10,0)
+      unify table p = rename p table p -- in 2.10.0: type Pred = Type
+#else
       unify table p@(ClassP n tys) = ClassP n (map (rename p table) tys)
       unify table p@(EqualP a b)   = EqualP (rename p table a) (rename p table b)
+#endif
 
       -- | rename the type variables in a Type
       rename :: Pred -> [(Name, Name)] -> Type -> Type


### PR DESCRIPTION
Hi,

unfortunately `acid-state` does not build on the latest ghc-7.10 due to some breaking changes in template-haskell.  I fixed this by using CPP and also fixed the benchmark build.

I am not completely sure that this is is the correct fix for it, can someone have a look and give some feedback?  

Best,
Markus