### PR TITLE
fix blocked in mvar when running out of disk space

### DIFF
--- a/src/Data/Acid/Log.hs
+++ b/src/Data/Acid/Log.hs
@@ -43,6 +43,7 @@ import Text.Printf                               ( printf )
 
 import Paths_acid_state                          ( version )
 import Data.Version                              ( showVersion )
+import Control.Exception                         ( handle, IOException )
 
 type EntryId = Int
 
@@ -87,7 +88,8 @@ openFileLog identifier = do
   currentState <- newEmptyMVar
   queue <- newTVarIO ([], [])
   nextEntryRef <- newTVarIO 0
-  tid2 <- forkIO $ fileWriter currentState queue
+  tid1 <- myThreadId
+  tid2 <- forkIO $ fileWriter currentState queue tid1
   let fLog = FileLog { logIdentifier  = identifier
                      , logCurrent     = currentState
                      , logNextEntryId = nextEntryRef
@@ -105,16 +107,17 @@ openFileLog identifier = do
              putMVar currentState handle
   return fLog
 
-fileWriter :: MVar FHandle -> TVar ([Lazy.ByteString], [IO ()]) -> IO ()
-fileWriter currentState queue = forever $ do
+fileWriter :: MVar FHandle -> TVar ([Lazy.ByteString], [IO ()]) -> ThreadId -> IO ()
+fileWriter currentState queue parentTid = forever $ do
   (entries, actions) <- atomically $ do
     (entries, actions) <- readTVar queue
     when (null entries && null actions) retry
     writeTVar queue ([], [])
     return (reverse entries, reverse actions)
-  withMVar currentState $ \fd -> do
-    let arch = Archive.packEntries entries
-    writeToDisk fd (repack arch)
+  handle (\e -> throwTo parentTid (e :: IOException)) $
+    withMVar currentState $ \fd -> do
+      let arch = Archive.packEntries entries
+      writeToDisk fd (repack arch)
   sequence_ actions
   yield
 


### PR DESCRIPTION
An issue occures when an Update is too big and the device runs out of space. To reproduce:

	m|v:~/acid-state/examples% sudo mount -t tmpfs -o size=13k none state
	m|v:~/acid-state/examples% runhaskell HelloWorld.hs
	The state is: Hello world
	m|v:~/acid-state/examples% runhaskell HelloWorld.hs "Some directories
	where tmpfs is commonly used are /tmp, /var/lock and /var/run. Do not use it
	on /var/tmp, because that folder is meant for temporary files that are
	preserved across reboots."
	HelloWorld.hs: fdWriteBuf: resource exhausted (No space left on device)
	HelloWorld.hs: thread blocked indefinitely in an MVar operation
	m|v:~/acid-state/examples%

Won't happen when there's so few space that no state-directory can be created:

	m|v:~/acid-state/examples% sudo mount -t tmpfs -o size=4k none state
	m|v:~/acid-state/examples% runhaskell HelloWorld.hs
	HelloWorld.hs: state/HelloWorldState/events.version: hClose: resource exhausted
	(No space left on device)
	m|v:~/acid-state/examples%

After patch we get a "clean" exit:

	m|v:~/acid-state/examples% runhaskell HelloWorld.hs "Some directories
	where tmpfs is commonly used are /tmp, /var/lock and /var/run. Do not use it
	on /var/tmp, because that folder is meant for temporary files that are
	preserved across reboots."
	HelloWorld.hs: fdWriteBuf: resource exhausted (No space left on device)
	m|v:~/acid-state/examples%
