### PR TITLE
Acid-state does not work with current cereal (0.5.0.0)

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -35,7 +35,7 @@ Library
   Build-depends:       array,
                        base >= 4 && < 5,
                        bytestring >= 0.10,
-                       cereal >= 0.4.1.0,
+                       cereal >= 0.4.1.0 && < 0.5,
                        containers,
                        extensible-exceptions,
                        safecopy >= 0.6,


### PR DESCRIPTION
Without this constraint build fails with

~~~
src/Data/Acid/Archive.hs:22:18:
    Could not find module ‘Data.Serialize.Builder’
    Perhaps you meant
      Data.Serialize.Put (from cereal-0.5.0.0)
      Data.Serialize.Get (from cereal-0.5.0.0)
    Use -v to see a list of the files searched for.
~~~