### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -71,12 +71,16 @@ benchmark loading-benchmark
     benchmarks/loading
   main-is:
     Benchmark.hs
+  other-modules:
+    Benchmark.FileSystem
+    Benchmark.Model
+    Benchmark.Prelude
   build-depends:
     random,
     directory,
     system-fileio == 0.3.*,
     system-filepath,
-    criterion >= 0.8 && < 1.1,
+    criterion >= 0.8 && < 1.2,
     mtl,
     base,
     acid-state


### PR DESCRIPTION
The `acid-state` benchmarks fail to build when obtained from Hackage since the tarball doesn't include three of the modules needed to compile them. This fixes the issue by explicitly adding them to the `other-modules` stanza.

Also increases the upper version bounds of `criterion` to allow the latest version.

See also https://github.com/iu-parfunc/sc-haskell/issues/7