### PR TITLE
GHC8 and TH-2.11.0 support

### DIFF
--- a/src/Data/Acid/Abstract.hs
+++ b/src/Data/Acid/Abstract.hs
@@ -48,7 +48,7 @@ data AcidState st
   = AcidState {
                 _scheduleUpdate :: forall event. (UpdateEvent event, EventState event ~ st) => event -> IO (MVar (EventResult event))
               , scheduleColdUpdate :: Tagged ByteString -> IO (MVar ByteString)
-              , _query :: (QueryEvent event, EventState event ~ st)  => event -> IO (EventResult event)
+              , _query :: forall event. (QueryEvent event, EventState event ~ st) => event -> IO (EventResult event)
               , queryCold :: Tagged ByteString -> IO ByteString
               ,
 -- | Take a snapshot of the state and save it to disk. Creating checkpoints


### PR DESCRIPTION
With this patch, acid-state (given that https://github.com/acid-state/safecopy/pull/40 merged) compiles with GHC8-rc4, I also tested that it successfully compiles with GHC-7.10.3.

I mostly followed https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#template-haskell-2.11.0.0 , and fixed type errors. I expect everything to work, since the changes are trivial.