### PR TITLE
Cut current events log before creating a local checkpoint

### DIFF
--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -179,7 +179,8 @@ localQueryCold acidState event
 --   This call will not return until the operation has succeeded.
 createLocalCheckpoint :: SafeCopy st => LocalState st -> IO ()
 createLocalCheckpoint acidState
-    = do mvar <- newEmptyMVar
+    = do cutFileLog (localEvents acidState)
+         mvar <- newEmptyMVar
          withCoreState (localCore acidState) $ \st ->
            do eventId <- askCurrentEntryId (localEvents acidState)
               pushAction (localEvents acidState) $


### PR DESCRIPTION
This ensures that the current events log does not grow indefinitely while
still containing all events that are newer than the checkpoint. With this
change, only events that happened between creating the new events log and
creating the checkpoint will be in both.

https://github.com/acid-state/acid-state/issues/73