### PR TITLE
Fix the GHC 8.2 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3
+    - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/src/Data/Acid/Core.hs
+++ b/src/Data/Acid/Core.hs
@@ -46,12 +46,16 @@ import Data.ByteString.Lazy.Char8 as Lazy ( pack, unpack )
 import Data.Serialize                     ( runPutLazy, runGetLazy )
 import Data.SafeCopy                      ( SafeCopy, safeGet, safePut )
 
-import Data.Typeable                      ( Typeable, TypeRep, typeOf )
+import Data.Typeable                      ( Typeable, TypeRep, typeRepTyCon, typeOf )
 import Unsafe.Coerce                      ( unsafeCoerce )
 
-#if MIN_VERSION_base(4,4,0)
+#if MIN_VERSION_base(4,5,0)
+import Data.Typeable                      ( tyConModule )
+#else
+import Data.Typeable.Internal             ( tyConModule )
+#endif
 
-import Data.Typeable.Internal             ( TypeRep (..), tyConModule )
+#if MIN_VERSION_base(4,4,0)
 
 -- in base >= 4.4 the Show instance for TypeRep no longer provides a
 -- fully qualified name. But we have old data around that expects the
@@ -60,12 +64,7 @@ import Data.Typeable.Internal             ( TypeRep (..), tyConModule )
 -- end-of-life anyway.
 showQualifiedTypeRep :: TypeRep -> String
 showQualifiedTypeRep tr = tyConModule con ++ "." ++ show tr
-  where con = extractTypeRepCon tr
-#if MIN_VERSION_base(4,8,0)
-        extractTypeRepCon (TypeRep _ c _ _) = c
-#else
-        extractTypeRepCon (TypeRep _ c _) = c
-#endif
+  where con = typeRepTyCon tr
 
 #else
 

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -226,7 +226,9 @@ makeEventHandler eventName eventType
 --  deriving (Typeable)
 makeEventDataType eventName eventType
     = do let con = normalC eventStructName [ strictType notStrict (return arg) | arg <- args ]
-#if MIN_VERSION_template_haskell(2,11,0)
+#if MIN_VERSION_template_haskell(2,12,0)
+             cxt = [derivClause Nothing [conT ''Typeable]]
+#elif MIN_VERSION_template_haskell(2,11,0)
              cxt = mapM conT [''Typeable]
 #else
              cxt = [''Typeable]


### PR DESCRIPTION
`acid-state` doesn't build on GHC 8.2 for two reasons:

* A minor Template Haskell change requires a small tweak.
* `base-4.10` no longer exports `Data.Typeable.Internal`. But it was importing it mostly to get the `TyCon` inside of a `TypeRep`, which can be done just as well with `typeRepTyCon`, which is available from the public `Data.Typeable` module on all versions on `base`. The `tyConModule` function is also available on _most_ versions of `base` (except for very old ones, so some CPP is still required for that).