### PR TITLE
Add Nix derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, array, base, bytestring, cereal, containers
+, directory, extensible-exceptions, filepath, mtl, network
+, safecopy, stdenv, stm, template-haskell, unix
+}:
+mkDerivation {
+  pname = "acid-state";
+  version = "0.14.2";
+  src = ./.;
+  libraryHaskellDepends = [
+    array base bytestring cereal containers directory
+    extensible-exceptions filepath mtl network safecopy stm
+    template-haskell unix
+  ];
+  homepage = "https://github.com/acid-state/acid-state";
+  description = "Add ACID guarantees to any serializable Haskell data structure";
+  license = stdenv.lib.licenses.publicDomain;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,5 @@
+let
+  pkgs = import <nixpkgs> {  };
+
+in
+  { acid-state = pkgs.haskellPackages.callPackage ./default.nix {}; }


### PR DESCRIPTION
`default.nix` was generated by running `cabal2nix . > default.nix` and `release.nix` was adapted from another project. `acid-state` was successfully built by running `nix-build release.nix`.

References #83.