### PR TITLE
Allow using Unix sockets as locks.

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -1,5 +1,5 @@
 Name:                acid-state
-Version:             0.14.3
+Version:             0.14.4
 Synopsis:            Add ACID guarantees to any serializable Haskell data structure.
 Description:         Use regular Haskell data structures as your database and get stronger ACID guarantees than most RDBMS offer.
 Homepage:            https://github.com/acid-state/acid-state
@@ -21,6 +21,10 @@ Extra-source-files:
 Source-repository head
   type:          git
   location:      https://github.com/acid-state/acid-state
+
+Flag Socket
+  Description:   Use unix sockets as a lock
+  Default:       False
 
 Library
   Exposed-Modules:     Data.Acid,
@@ -60,6 +64,9 @@ Library
   else
      Hs-Source-Dirs:   src-unix/
 
+  if flag(socket)
+     cpp-options:      -DUSE_UNIX_SOCKET_AS_LOCK
+
   default-language:    Haskell2010
   GHC-Options:         -fwarn-unused-imports -fwarn-unused-binds
 
@@ -78,7 +85,7 @@ benchmark loading-benchmark
     Benchmark.Prelude
   build-depends:
     random,
-    directory,
+    directory >= 1.2.2,
     system-fileio == 0.3.*,
     system-filepath,
     criterion >= 0.8 && < 1.2,


### PR DESCRIPTION
PID file suffer from an issue which is that they are not collected when
the process is abruptly killed. If it happens that before relaunch, a
process reuse the PID of the killed process, then one must externally
clean the PID file.

This patch defines a new compilation flag (--socket) which uses a unix
socket from the abstract namespace as the lock rather than a PID file.

Unfortunately, this option is not portable across all *nix flavours,
only recent Linux versions support it.

A less problematic, but still noticeable effect is that the PID of the
locking process was being advised in the error message. This is not
the case anymore, but this was not the case on Windows anyway.