### PR TITLE
Fixed the bug with process killing with SIGKILL by using FileLock library #89

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -43,6 +43,7 @@ Library
                        safecopy >= 0.6,
                        stm >= 2.4,
                        directory,
+                       filelock,
                        filepath,
                        mtl,
                        network,

--- a/src-unix/FileIO.hs
+++ b/src-unix/FileIO.hs
@@ -1,30 +1,16 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-module FileIO(FHandle,open,write,flush,close,obtainPrefixLock,releasePrefixLock,PrefixLock) where
+module FileIO(FHandle,open,write,flush,close) where
 import System.Posix(Fd(Fd),
                     openFd,
                     fdWriteBuf,
-                    fdToHandle,
                     closeFd,
-                    OpenMode(WriteOnly,ReadWrite),
-                    exclusive, trunc,
+                    OpenMode(WriteOnly),
                     defaultFileFlags,
                     stdFileMode
                    )
 import Data.Word(Word8,Word32)
 import Foreign(Ptr)
 import Foreign.C(CInt(..))
-import System.IO
-
-import Data.Maybe (listToMaybe)
-import qualified System.IO.Error as SE
-import System.Posix.Process (getProcessID)
-import System.Posix.Signals (nullSignal, signalProcess)
-import System.Posix.Types (ProcessID)
-import Control.Exception.Extensible as E
-import System.Directory         ( createDirectoryIfMissing, removeFile)
-import System.FilePath
-
-newtype PrefixLock = PrefixLock FilePath
 
 data FHandle = FHandle Fd
 
@@ -43,111 +29,3 @@ foreign import ccall "fsync" c_fsync :: CInt -> IO CInt
 
 close :: FHandle -> IO ()
 close (FHandle fd) = closeFd fd
-
--- Unix needs to use a special open call to open files for exclusive writing
---openExclusively :: FilePath -> IO Handle
---openExclusively fp =
---    fdToHandle =<< openFd fp ReadWrite (Just 0o600) flags
---    where flags = defaultFileFlags {exclusive = True, trunc = True}
-
-
-
-
-obtainPrefixLock :: FilePath -> IO PrefixLock
-obtainPrefixLock prefix = do
-    checkLock fp >> takeLock fp
-    where fp = prefix ++ ".lock"
-
--- |Read the lock and break it if the process is dead.
-checkLock :: FilePath -> IO ()
-checkLock fp = readLock fp >>= maybeBreakLock fp
-
--- |Read the lock and return the process id if possible.
-readLock :: FilePath -> IO (Maybe ProcessID)
-readLock fp = try (readFile fp) >>=
-              return . either (checkReadFileError fp) (fmap (fromInteger . read) . listToMaybe . lines)
-
--- |Is this a permission error?  If so we don't have permission to
--- remove the lock file, abort.
-checkReadFileError :: [Char] -> IOError -> Maybe ProcessID
-checkReadFileError fp e | SE.isPermissionError e = throw (userError ("Could not read lock file: " ++ show fp))
-                        | SE.isDoesNotExistError e = Nothing
-                        | True = throw e
-
-maybeBreakLock :: FilePath -> Maybe ProcessID -> IO ()
-maybeBreakLock fp Nothing =
-    -- The lock file exists, but there's no PID in it.  At this point,
-    -- we will break the lock, because the other process either died
-    -- or will give up when it failed to read its pid back from this
-    -- file.
-    breakLock fp
-maybeBreakLock fp (Just pid) = do
-  -- The lock file exists and there is a PID in it.  We can break the
-  -- lock if that process has died.
-  -- getProcessStatus only works on the children of the calling process.
-  -- exists <- try (getProcessStatus False True pid) >>= either checkException (return . isJust)
-  exists <- doesProcessExist pid
-  case exists of
-    True -> throw (lockedBy fp pid)
-    False -> breakLock fp
-
-doesProcessExist :: ProcessID -> IO Bool
-doesProcessExist pid =
-    -- Implementation 1
-    -- doesDirectoryExist ("/proc/" ++ show pid)
-    -- Implementation 2
-    try (signalProcess nullSignal pid) >>= return . either checkException (const True)
-    where checkException e | SE.isDoesNotExistError e = False
-                           | True = throw e
-
--- |We have determined the locking process is gone, try to remove the
--- lock.
-breakLock :: FilePath -> IO ()
-breakLock fp = try (removeFile fp) >>= either checkBreakError (const (return ()))
-
--- |An exception when we tried to break a lock, if it says the lock
--- file has already disappeared we are still good to go.
-checkBreakError :: IOError -> IO ()
-checkBreakError e | SE.isDoesNotExistError e = return ()
-                  | True = throw e
-
--- |Try to create lock by opening the file with the O_EXCL flag and
--- writing our PID into it.  Verify by reading the pid back out and
--- matching, maybe some other process slipped in before we were done
--- and broke our lock.
-takeLock :: FilePath -> IO PrefixLock
-takeLock fp = do
-  createDirectoryIfMissing True (takeDirectory fp)
-  h <- openFd fp ReadWrite (Just 0o600) (defaultFileFlags {exclusive = True, trunc = True}) >>= fdToHandle
-  pid <- getProcessID
-  hPutStrLn h (show pid) >> hClose h
-  -- Read back our own lock and make sure its still ours
-  readLock fp >>= maybe (throw (cantLock fp pid))
-                        (\ pid' -> if pid /= pid'
-                                   then throw (stolenLock fp pid pid')
-                                   else return (PrefixLock fp))
-
--- |An exception saying the data is locked by another process.
-lockedBy :: (Show a) => FilePath -> a -> SomeException
-lockedBy fp pid = SomeException (SE.mkIOError SE.alreadyInUseErrorType ("Locked by " ++ show pid) Nothing (Just fp))
-
--- |An exception saying we don't have permission to create lock.
-cantLock :: FilePath -> ProcessID -> SomeException
-cantLock fp pid = SomeException (SE.mkIOError SE.alreadyInUseErrorType ("Process " ++ show pid ++ " could not create a lock") Nothing (Just fp))
-
--- |An exception saying another process broke our lock before we
--- finished creating it.
-stolenLock :: FilePath -> ProcessID -> ProcessID -> SomeException
-stolenLock fp pid pid' = SomeException (SE.mkIOError SE.alreadyInUseErrorType ("Process " ++ show pid ++ "'s lock was stolen by process " ++ show pid') Nothing (Just fp))
-
--- |Relinquish the lock by removing it and then verifying the removal.
-releasePrefixLock :: PrefixLock -> IO ()
-releasePrefixLock (PrefixLock fp) =
-    dropLock >>= either checkDrop return
-    where
-      dropLock = try (removeFile fp)
-      checkDrop e | SE.isDoesNotExistError e = return ()
-                  | True = throw e
-
-
-

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -30,22 +30,21 @@ import Data.Acid.Common
 import Data.Acid.Abstract
 
 import Control.Concurrent             ( newEmptyMVar, putMVar, takeMVar, MVar )
-import Control.Exception              ( onException, evaluate )
+import Control.Exception              ( onException, evaluate, Exception, throwIO )
 import Control.Monad.State            ( runState )
 import Control.Monad                  ( join )
 import Control.Applicative            ( (<$>), (<*>) )
 import Data.ByteString.Lazy           ( ByteString )
 import qualified Data.ByteString.Lazy as Lazy ( length )
 
-
 import Data.Serialize                 ( runPutLazy, runGetLazy )
 import Data.SafeCopy                  ( SafeCopy(..), safeGet, safePut
                                       , primitive, contain )
 import Data.Typeable                  ( Typeable, typeOf )
 import Data.IORef
-import System.FilePath                ( (</>) )
-
-import FileIO                         ( obtainPrefixLock, releasePrefixLock, PrefixLock )
+import System.FilePath                ( (</>), takeDirectory )
+import System.FileLock
+import System.Directory               ( createDirectoryIfMissing )
 
 
 {-| State container offering full ACID (Atomicity, Consistency, Isolation and Durability)
@@ -66,9 +65,12 @@ data LocalState st
                  , localCopy        :: IORef st
                  , localEvents      :: FileLog (Tagged ByteString)
                  , localCheckpoints :: FileLog Checkpoint
-                 , localLock        :: PrefixLock
+                 , localLock        :: FileLock
                  } deriving (Typeable)
 
+newtype StateIsLocked = StateIsLocked FilePath deriving (Show, Typeable)
+
+instance Exception StateIsLocked
 
 -- | Issue an Update event and return immediately. The event is not durable
 --   before the MVar has been filled but the order of events is honored.
@@ -201,7 +203,7 @@ createCheckpointAndClose abstract_state
          takeMVar mvar
          closeFileLog (localEvents acidState)
          closeFileLog (localCheckpoints acidState)
-         releasePrefixLock (localLock acidState)
+         unlockFile (localLock acidState)
   where acidState = downcast abstract_state
 
 
@@ -278,11 +280,11 @@ resumeLocalStateFrom directory initialState delayLocking =
     True -> do
       (n, st) <- loadCheckpoint
       return $ do
-        lock  <- obtainPrefixLock lockFile
+        lock  <- maybeLockFile lockFile
         replayEvents lock n st
     False -> do
-      lock    <- obtainPrefixLock lockFile
-      (n, st) <- loadCheckpoint `onException` releasePrefixLock lock
+      lock    <- maybeLockFile lockFile
+      (n, st) <- loadCheckpoint `onException` unlockFile lock
       return $ do
         replayEvents lock n st
   where
@@ -317,9 +319,15 @@ resumeLocalStateFrom directory initialState delayLocking =
                                       , localCheckpoints = checkpointsLog
                                       , localLock = lock
                                       }
+    maybeLockFile path = do
+      createDirectoryIfMissing True (takeDirectory path)
+      maybe (throwIO (StateIsLocked path))
+                            pure =<< tryLockFile path Exclusive
+
 
 checkpointRestoreError msg
     = error $ "Could not parse saved checkpoint due to the following error: " ++ msg
+
 
 -- | Close an AcidState and associated logs.
 --   Any subsequent usage of the AcidState will throw an exception.
@@ -328,7 +336,7 @@ closeLocalState acidState
     = do closeCore (localCore acidState)
          closeFileLog (localEvents acidState)
          closeFileLog (localCheckpoints acidState)
-         releasePrefixLock (localLock acidState)
+         unlockFile (localLock acidState)
 
 createLocalArchive :: LocalState st -> IO ()
 createLocalArchive state
@@ -361,4 +369,3 @@ toAcidState local
               , closeAcidState = closeLocalState local
               , acidSubState = mkAnyState local
               }
-

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -322,7 +322,7 @@ resumeLocalStateFrom directory initialState delayLocking =
     maybeLockFile path = do
       createDirectoryIfMissing True (takeDirectory path)
       maybe (throwIO (StateIsLocked path))
-                            pure =<< tryLockFile path Exclusive
+                            return =<< tryLockFile path Exclusive
 
 
 checkpointRestoreError msg


### PR DESCRIPTION
We fixed the bug with process killing described in the issue #89. We used the filelock library instead the current solution with PIDs and lockfiles. For details, see changes in files.

We have already tested this update on MacOs and Windows using the code described below:

```haskell
import           Control.Monad.Reader
import           Control.Monad.State
import           Data.Acid
import           Data.SafeCopy
import           Data.Typeable
import           System.Environment()
import           Control.Concurrent (threadDelay)
import           Control.Exception (bracket)

data HelloWorldState = HelloWorldState String
    deriving (Show, Typeable)

$(deriveSafeCopy 0 'base ''HelloWorldState)

writeState :: String -> Update HelloWorldState ()
writeState newValue
    = put (HelloWorldState newValue)

queryState :: Query HelloWorldState String
queryState = do HelloWorldState string <- ask
                return string

$(makeAcidic ''HelloWorldState ['writeState, 'queryState])

main :: IO ()
main = bracket (openLocalState (HelloWorldState "Hello world")) (closeAcidState) $ \_ -> do
    threadDelay 100500100
```
1) Launch this code, is works.
2) Launch this executable again in the parallel tab, but it fails.
3) Kill forcefully the appropriate process (`kill -9 <EXE>` or `Taskkill /IM <EXE> /F`).
4) Again launch this, it works without any problems.