### PR TITLE
Relax type requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/**
 *.swp
+dist-newstyle/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ script:
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
 
   # Build with installed constraints for packages in global-db
-  - if $INSTALLED; then echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh; else echo "Not building with installed constraints"; fi
+  # - if $INSTALLED; then echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh; else echo "Not building with installed constraints"; fi
 
   # build & run tests, build benchmarks
   - cabal new-build -w ${HC} ${TEST} ${BENCH} all

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_cache:
 matrix:
   include:
     - compiler: "ghc-7.6.3"
-      env: NOINSTALLEDCONSTRAINTS=true
+      env: INSTALLED=false
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_cache:
 matrix:
   include:
     - compiler: "ghc-7.6.3"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      env: NOINSTALLEDCONSTRAINTS=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
@@ -94,7 +94,7 @@ script:
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
 
   # Build with installed constraints for packages in global-db
-  # - if $INSTALLED; then echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh; else echo "Not building with installed constraints"; fi
+  - if $INSTALLED; then echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh; else echo "Not building with installed constraints"; fi
 
   # build & run tests, build benchmarks
   - cabal new-build -w ${HC} ${TEST} ${BENCH} all

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -74,9 +74,11 @@ test-suite specs
                      , acid-state
                      , deepseq
                      , hspec
+                     , hspec-discover
                      , mtl
                      , safecopy
                      , template-haskell
+  build-tool-depends: hspec-discover:hspec-discover
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   other-modules:       Data.Acid.TemplateHaskellSpec
   default-language:    Haskell2010

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -28,11 +28,12 @@ Library
                        Data.Acid.Memory.Pure, Data.Acid.Remote,
                        Data.Acid.Advanced,
                        Data.Acid.Log, Data.Acid.CRC,
-                       Data.Acid.Abstract, Data.Acid.Core
+                       Data.Acid.Abstract, Data.Acid.Core,
+                       Data.Acid.TemplateHaskell
 
   Other-modules:       Data.Acid.Archive,
                        Paths_acid_state,
-                       Data.Acid.TemplateHaskell, Data.Acid.Common, FileIO
+                       Data.Acid.Common, FileIO
 
   Build-depends:       array,
                        base >= 4 && < 5,
@@ -65,6 +66,18 @@ Library
   default-language:    Haskell2010
   GHC-Options:         -fwarn-unused-imports -fwarn-unused-binds
 
+test-suite specs
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:       base
+                     , acid-state
+                     , hspec
+                     , template-haskell
+                     , mtl
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  other-modules:       Data.Acid.TemplateHaskellSpec
+  default-language:    Haskell2010
 
 
 benchmark loading-benchmark

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -36,7 +36,7 @@ Library
                        Data.Acid.Common, FileIO
 
   Build-depends:       array,
-                       base >= 4 && < 5,
+                       base >= 4.5.1.0 && < 5,
                        bytestring >= 0.10.2,
                        cereal >= 0.4.1.0,
                        containers,

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -100,7 +100,7 @@ benchmark loading-benchmark
     directory,
     system-fileio == 0.3.*,
     system-filepath,
-    criterion >= 0.8 && < 1.2,
+    criterion >= 0.8 && < 1.3,
     mtl,
     base,
     acid-state

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -72,9 +72,11 @@ test-suite specs
   main-is:             Spec.hs
   build-depends:       base
                      , acid-state
+                     , deepseq
                      , hspec
-                     , template-haskell
                      , mtl
+                     , safecopy
+                     , template-haskell
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   other-modules:       Data.Acid.TemplateHaskellSpec
   default-language:    Haskell2010

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -100,7 +100,7 @@ benchmark loading-benchmark
     directory,
     system-fileio == 0.3.*,
     system-filepath,
-    criterion >= 0.8 && < 1.3,
+    criterion >= 0.8 && < 1.5,
     mtl,
     base,
     acid-state

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -47,7 +47,8 @@ Library
                        filepath,
                        mtl,
                        network,
-                       template-haskell
+                       template-haskell,
+                       th-expand-syns
 
   if os(windows)
      Build-depends:       Win32

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE TemplateHaskell, CPP #-}
 {- Holy crap this code is messy. -}
-module Data.Acid.TemplateHaskell
-    ( makeAcidic
-    ) where
+module Data.Acid.TemplateHaskell where
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Ppr
@@ -344,7 +342,6 @@ makeEventInstance eventName eventType
           eventStructName = mkName (structName (nameBase eventName))
           structName [] = []
           structName (x:xs) = toUpper x : xs
-
 
 -- (tyvars, cxt, args, state type, result type, is update)
 analyseType :: Name -> Type -> ([TyVarBndr], Cxt, [Type], Type, Type, Bool)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 packages:
     - .
 
-resolver: lts-2.22
+resolver: lts-11.15
 
 extra-deps:
     - filelock-0.1.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+packages:
+    - .
+
+resolver: lts-2.22
+
+extra-deps:
+    - filelock-0.1.0.1

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RankNTypes #-}

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Data.Acid.TemplateHaskellSpec where
+
+import Test.Hspec
+
+import Data.Acid
+import Data.Acid.TemplateHaskell
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+import Control.Monad.Reader
+import Control.Monad.State
+
+spec :: Spec
+spec = do
+    describe "analyseType" $ do
+        it "can work with the Query type" $ do
+            let typs = [ConT ''Int]
+                name = mkName "foo"
+                isUpdate = False
+                stateType = ConT ''String
+                resultType = ConT ''Char
+                args = [ConT ''Int]
+                ctx = []
+                tvb = []
+            typ <- runQ [t| Int -> Query String Char |]
+
+            analyseType name typ
+                `shouldBe`
+                    ( tvb
+                    , ctx
+                    , typs
+                    , stateType
+                    , resultType
+                    , isUpdate
+                    )
+
+        it "can work with MonadReader" $ do
+            let typs = [ConT ''Int]
+                name = mkName "foo"
+                isUpdate = False
+                stateType = ConT ''Int
+                resultType = TupleT 0
+                args = [ConT ''Int]
+                ctx = []
+                tvb = []
+            typ <- runQ [t| (MonadReader Int m) => Int -> m () |]
+            analyseType name typ
+                `shouldBe`
+                    ( tvb
+                    , ctx
+                    , typs
+                    , stateType
+                    , resultType
+                    , isUpdate
+                    )
+
+        it "can work with many type variables" $ do
+            let typs = [ConT ''Int]
+                name = mkName "foo"
+                isUpdate = False
+                stateType = ConT ''Int
+                resultType = VarT m `AppT` TupleT 0
+                args = [ConT ''Int]
+                m = mkName "m"
+                ctx =
+#if MIN_VERSION_template_haskell(2,10,0)
+                    [ ConT ''MonadReader
+                        `AppT` ConT ''Int
+                        `AppT` VarT m
+                    ]
+#else
+                    [ ClassP ''MonadReader [ConT ''Int, VarT m]
+                    ]
+#endif
+
+                tvb = []
+            typ <- runQ [t| (MonadReader Int $(varT m)) => Int -> Query Int ($(varT m) ()) |]
+            analyseType name typ
+                `shouldBe`
+                    ( tvb
+                    , ctx
+                    , typs
+                    , stateType
+                    , resultType
+                    , isUpdate
+                    )

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -60,7 +60,7 @@ spec = do
                     }
 
         it "can work with MonadReader" $ do
-            typ <- runQ [t| (MonadReader Int m) => Int -> m () |]
+            typ <- runQ [t| forall m. (MonadReader Int m) => Int -> m () |]
             analyseType name typ
                 `shouldBe` TypeAnalysis
                     { tyvars = []
@@ -102,7 +102,7 @@ spec = do
                         . force
                         . map show
                         $ eventCxts stateType binders name eventType
-            eventType <- runQ [t| (Ord a) => Int -> Query Char a |]
+            eventType <- runQ [t| forall a. (Ord a) => Int -> Query Char a |]
 
             predicate eventType
                 `shouldThrow`
@@ -119,7 +119,7 @@ spec = do
         it "accepts constrained type variables in the state" $ do
             let binders = [PlainTV (mkName "x")]
                 stateType = ConT ''Maybe `AppT` VarT x
-            eventType <- runQ [t| (Ord a) => Int -> Query (Maybe a) Int|]
+            eventType <- runQ [t| forall a. (Ord a) => Int -> Query (Maybe a) Int|]
 
             eventCxts stateType binders name eventType
                 `shouldBe`
@@ -130,7 +130,7 @@ spec = do
 #endif
 
         it "can rename a polymorphic state" $ do
-            eventType <- runQ [t| (MonadReader r m, Ord r) => Int -> m Char |]
+            eventType <- runQ [t| forall r m. (MonadReader r m, Ord r) => Int -> m Char |]
             eventCxts stateType binders name eventType
                 `shouldBe`
 #if MIN_VERSION_template_haskell(2,10,0)

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -42,7 +44,7 @@ spec = do
                     , isUpdate = False
                     }
 
-        it "can work with many type variables" $ do
+        it "can work with many type variables (note that eventCxts later rejects this)" $ do
             let m = mkName "m"
             typ <- runQ [t| (MonadReader Int $(varT m)) => Int -> Query Int ($(varT m) ()) |]
             analyseType name typ

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -4,7 +4,7 @@
 
 module Data.Acid.TemplateHaskellSpec where
 
-import Test.Hspec
+import Test.Hspec hiding (context)
 
 import Data.Acid
 import Data.Acid.TemplateHaskell
@@ -16,74 +16,50 @@ import Control.Monad.State
 spec :: Spec
 spec = do
     describe "analyseType" $ do
+        let name = mkName "foo"
         it "can work with the Query type" $ do
-            let typs = [ConT ''Int]
-                name = mkName "foo"
-                isUpdate = False
-                stateType = ConT ''String
-                resultType = ConT ''Char
-                args = [ConT ''Int]
-                ctx = []
-                tvb = []
             typ <- runQ [t| Int -> Query String Char |]
 
             analyseType name typ
-                `shouldBe`
-                    ( tvb
-                    , ctx
-                    , typs
-                    , stateType
-                    , resultType
-                    , isUpdate
-                    )
+                `shouldBe` TypeAnalysis
+                    { tyvars = []
+                    , context = []
+                    , argumentTypes = [ConT ''Int]
+                    , stateType = ConT ''String
+                    , resultType = ConT ''Char
+                    , isUpdate = False
+                    }
 
         it "can work with MonadReader" $ do
-            let typs = [ConT ''Int]
-                name = mkName "foo"
-                isUpdate = False
-                stateType = ConT ''Int
-                resultType = TupleT 0
-                args = [ConT ''Int]
-                ctx = []
-                tvb = []
             typ <- runQ [t| (MonadReader Int m) => Int -> m () |]
             analyseType name typ
-                `shouldBe`
-                    ( tvb
-                    , ctx
-                    , typs
-                    , stateType
-                    , resultType
-                    , isUpdate
-                    )
+                `shouldBe` TypeAnalysis
+                    { tyvars = []
+                    , context = []
+                    , argumentTypes = [ConT ''Int]
+                    , stateType = ConT ''Int
+                    , resultType = TupleT 0
+                    , isUpdate = False
+                    }
 
         it "can work with many type variables" $ do
-            let typs = [ConT ''Int]
-                name = mkName "foo"
-                isUpdate = False
-                stateType = ConT ''Int
-                resultType = VarT m `AppT` TupleT 0
-                args = [ConT ''Int]
-                m = mkName "m"
-                ctx =
-#if MIN_VERSION_template_haskell(2,10,0)
-                    [ ConT ''MonadReader
-                        `AppT` ConT ''Int
-                        `AppT` VarT m
-                    ]
-#else
-                    [ ClassP ''MonadReader [ConT ''Int, VarT m]
-                    ]
-#endif
-
-                tvb = []
+            let m = mkName "m"
             typ <- runQ [t| (MonadReader Int $(varT m)) => Int -> Query Int ($(varT m) ()) |]
             analyseType name typ
-                `shouldBe`
-                    ( tvb
-                    , ctx
-                    , typs
-                    , stateType
-                    , resultType
-                    , isUpdate
-                    )
+                `shouldBe` TypeAnalysis
+                    { tyvars = []
+                    , context =
+#if MIN_VERSION_template_haskell(2,10,0)
+                        [ ConT ''MonadReader
+                            `AppT` ConT ''Int
+                            `AppT` VarT m
+                        ]
+#else
+                        [ ClassP ''MonadReader [ConT ''Int, VarT m]
+                        ]
+#endif
+                    , argumentTypes = [ConT ''Int]
+                    , stateType = ConT ''Int
+                    , resultType = VarT m `AppT` TupleT 0
+                    , isUpdate = False
+                    }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
From @neongreen's original commit message:

>  Previously acid-state only supported these event types (with
> variations):
> 
>     foo :: a -> b -> Update st ()
>     bar :: a -> b -> Query st ()
> 
> This commit adds support for the following event types:
> 
>     foo :: MonadState  st m => a -> b -> m ()
>     bar :: MonadReader st m => a -> b -> m ()
> 
> as well as their more complex variations:
> 
>     foo :: (MonadState  st m, Blah st) => a -> b -> m ()
>     bar :: (MonadReader st m, Blah st) => a -> b -> m ()
> 
>     foo :: a -> b -> (forall st m. (MonadState  st m, Blah st) => m ())
>     bar :: a -> b -> (forall st m. (MonadReader st m, Blah st) => m ())
> 
> It hasn't been tested on template-haskell-2.9 and earlier. It also
> relaxes some restrictions put on 'forall's in type signatures, and
> thus will probably produce an invalid type in some cases where
> previously it would've failed with an error.

We are using this at IOHK. It allows us to reuse functionality that's defined for `acid-state` querying on a pure, in-memory value of that type. Also, it allows you to write a type synonym `type Q a = Query MyStateType a` and `acid-state` won't reject it.