### PR TITLE
Modular serialisation

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -24,6 +24,7 @@ Source-repository head
 
 Library
   Exposed-Modules:     Data.Acid,
+                       Data.Acid.Archive,
                        Data.Acid.Local, Data.Acid.Memory,
                        Data.Acid.Memory.Pure, Data.Acid.Remote,
                        Data.Acid.Advanced,
@@ -31,8 +32,7 @@ Library
                        Data.Acid.Abstract, Data.Acid.Core,
                        Data.Acid.TemplateHaskell
 
-  Other-modules:       Data.Acid.Archive,
-                       Paths_acid_state,
+  Other-modules:       Paths_acid_state,
                        Data.Acid.Common, FileIO
 
   Build-depends:       array,

--- a/examples/HelloWorldNoTH.hs
+++ b/examples/HelloWorldNoTH.hs
@@ -77,6 +77,6 @@ instance QueryEvent QueryState
 
 
 instance IsAcidic HelloWorldState where
-    acidEvents = [ UpdateEvent (\(WriteState newState) -> writeState newState)
-                 , QueryEvent (\QueryState             -> queryState)
+    acidEvents = [ UpdateEvent (\(WriteState newState) -> writeState newState) safeCopyMethodSerialiser
+                 , QueryEvent (\QueryState             -> queryState)          safeCopyMethodSerialiser
                  ]

--- a/examples/KeyValueNoTH.hs
+++ b/examples/KeyValueNoTH.hs
@@ -93,6 +93,6 @@ instance Method LookupKey where
 instance QueryEvent LookupKey
 
 instance IsAcidic KeyValue where
-    acidEvents = [ UpdateEvent (\(InsertKey key value) -> insertKey key value)
-                 , QueryEvent (\(LookupKey key) -> lookupKey key)
+    acidEvents = [ UpdateEvent (\(InsertKey key value) -> insertKey key value) safeCopyMethodSerialiser
+                 , QueryEvent (\(LookupKey key) -> lookupKey key)              safeCopyMethodSerialiser
                  ]

--- a/examples/StressTestNoTH.hs
+++ b/examples/StressTestNoTH.hs
@@ -84,6 +84,6 @@ instance Method QueryState where
 instance QueryEvent QueryState
 
 instance IsAcidic StressState where
-    acidEvents = [ UpdateEvent (\PokeState -> pokeState)
-                 , QueryEvent (\QueryState -> queryState)
+    acidEvents = [ UpdateEvent (\PokeState -> pokeState)  safeCopyMethodSerialiser
+                 , QueryEvent (\QueryState -> queryState) safeCopyMethodSerialiser
                  ]

--- a/src/Data/Acid/Advanced.hs
+++ b/src/Data/Acid/Advanced.hs
@@ -17,9 +17,14 @@ module Data.Acid.Advanced
     , Method(..)
     , IsAcidic(..)
     , Event(..)
+
+    , safeCopySerialiser
+    , safeCopyMethodSerialiser
+    , defaultArchiver
     ) where
 
 import Data.Acid.Abstract
+import Data.Acid.Archive
 import Data.Acid.Core
 import Data.Acid.Common
 

--- a/src/Data/Acid/Archive.hs
+++ b/src/Data/Acid/Archive.hs
@@ -12,6 +12,8 @@ module Data.Acid.Archive
     , readEntries
     , entriesToList
     , entriesToListNoFail
+    , Archiver(..)
+    , defaultArchiver
     ) where
 
 import           Data.Acid.CRC
@@ -23,19 +25,64 @@ import           Data.Monoid
 import           Data.Serialize.Get     hiding (Result (..))
 import qualified Data.Serialize.Get     as Serialize
 
+-- | A bytestring that represents an entry in an archive.
 type Entry = Lazy.ByteString
+
+-- | Result of unpacking an archive.  This is essentially a list of
+-- 'Entry', but may terminate in 'Fail' if the archive format is
+-- incorrect.
 data Entries = Done | Next Entry Entries | Fail String
     deriving (Show)
 
+-- | Convert 'Entries' to a normal list, calling 'error' if there was
+-- a failure in unpacking the archive.
 entriesToList :: Entries -> [Entry]
 entriesToList Done              = []
 entriesToList (Next entry next) = entry : entriesToList next
 entriesToList (Fail msg)        = error msg
 
+-- | Convert 'Entries' to a normal list, silently ignoring a failure
+-- to unpack the archive and instead returning a truncated list.
 entriesToListNoFail :: Entries -> [Entry]
 entriesToListNoFail Done              = []
 entriesToListNoFail (Next entry next) = entry : entriesToListNoFail next
 entriesToListNoFail Fail{}            = []
+
+
+-- | Interface for the lowest level of the serialisation layer, which
+-- handles packing lists of 'Entry' elements (essentially just
+-- bytestrings) into a single bytestring, perhaps with error-checking.
+--
+-- Any @'Archiver'{'archiveWrite', 'archiveRead'}@ must satisfy the
+-- round-trip property:
+--
+-- > forall xs . entriesToList (archiveRead (archiveWrite xs)) == xs
+--
+-- Moreover, 'archiveWrite' must be a monoid homomorphism, so that
+-- concatenating archives is equivalent to concatenating the lists of
+-- entries that they represent:
+--
+-- > archiveWrite [] == empty
+-- > forall xs ys . archiveWrite xs <> archiveWrite ys == archiveWrite (xs ++ ys)
+data Archiver
+    = Archiver
+      { archiveWrite :: [Entry] -> Lazy.ByteString
+        -- ^ Pack a list of entries into a bytestring.
+
+      , archiveRead  :: Lazy.ByteString -> Entries
+        -- ^ Unpack a bytestring as a list of 'Entries', including the
+        -- possibility of failure if the format is invalid.
+      }
+
+-- | Standard (and historically the only) implementation of the
+-- 'Archiver' interface.  This represents each entry in the following
+-- format:
+--
+-- > | entry length | crc16   | entry   |
+-- > | 8 bytes      | 2 bytes | n bytes |
+defaultArchiver :: Archiver
+defaultArchiver = Archiver packEntries readEntries
+
 
 putEntry :: Entry -> Builder
 putEntry content

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -15,15 +15,21 @@
 module Data.Acid.Local
     ( openLocalState
     , openLocalStateFrom
+    , openLocalStateWithSerialiser
     , prepareLocalState
     , prepareLocalStateFrom
+    , prepareLocalStateWithSerialiser
+    , defaultStateDirectory
     , scheduleLocalUpdate'
     , scheduleLocalColdUpdate'
     , createCheckpointAndClose
     , LocalState(..)
     , Checkpoint(..)
+    , SerialisationLayer(..)
+    , defaultSerialisationLayer
     ) where
 
+import Data.Acid.Archive
 import Data.Acid.Log as Log
 import Data.Acid.Core
 import Data.Acid.Common
@@ -64,7 +70,7 @@ data LocalState st
     = LocalState { localCore        :: Core st
                  , localCopy        :: IORef st
                  , localEvents      :: FileLog (Tagged ByteString)
-                 , localCheckpoints :: FileLog Checkpoint
+                 , localCheckpoints :: FileLog (Checkpoint st)
                  , localLock        :: FileLock
                  } deriving (Typeable)
 
@@ -85,7 +91,7 @@ instance Exception StateIsLocked
 scheduleLocalUpdate :: UpdateEvent event => LocalState (EventState event) -> event -> IO (MVar (EventResult event))
 scheduleLocalUpdate acidState event
     = do mvar <- newEmptyMVar
-         let encoded = runPutLazy (safePut event)
+         let encoded = encodeMethod ms event
 
          -- It is important that we encode the event now so that we can catch
          -- any exceptions (see nestedStateError in examples/errors/Exceptions.hs)
@@ -99,7 +105,7 @@ scheduleLocalUpdate acidState event
                                                                                 putMVar mvar result
               return st'
          return mvar
-    where hotMethod = lookupHotMethod (coreMethods (localCore acidState)) event
+    where (hotMethod, ms) = lookupHotMethodAndSerialiser (coreMethods (localCore acidState)) event
 
 -- | Same as scheduleLocalUpdate but does not immediately change the localCopy
 -- and return the result mvar - returns an IO action to do this instead. Take
@@ -108,7 +114,7 @@ scheduleLocalUpdate acidState event
 scheduleLocalUpdate' :: UpdateEvent event => LocalState (EventState event) -> event -> MVar (EventResult event) -> IO (IO ())
 scheduleLocalUpdate' acidState event mvar
     = do
-         let encoded = runPutLazy (safePut event)
+         let encoded = encodeMethod ms event
 
          -- It is important that we encode the event now so that we can catch
          -- any exceptions (see nestedStateError in examples/errors/Exceptions.hs)
@@ -125,7 +131,7 @@ scheduleLocalUpdate' acidState event mvar
          -- this is the action to update state for queries and release the
          -- result into the supplied mvar
          return act
-    where hotMethod = lookupHotMethod (coreMethods (localCore acidState)) event
+    where (hotMethod, ms) = lookupHotMethodAndSerialiser (coreMethods (localCore acidState)) event
 
 scheduleLocalColdUpdate :: LocalState st -> Tagged ByteString -> IO (MVar ByteString)
 scheduleLocalColdUpdate acidState event
@@ -179,27 +185,26 @@ localQueryCold acidState event
 --   with this call.
 --
 --   This call will not return until the operation has succeeded.
-createLocalCheckpoint :: SafeCopy st => LocalState st -> IO ()
+createLocalCheckpoint :: IsAcidic st => LocalState st -> IO ()
 createLocalCheckpoint acidState
     = do cutFileLog (localEvents acidState)
          mvar <- newEmptyMVar
          withCoreState (localCore acidState) $ \st ->
            do eventId <- askCurrentEntryId (localEvents acidState)
               pushAction (localEvents acidState) $
-                do let encoded = runPutLazy (safePut st)
-                   pushEntry (localCheckpoints acidState) (Checkpoint eventId encoded) (putMVar mvar ())
+                pushEntry (localCheckpoints acidState) (Checkpoint eventId st) (putMVar mvar ())
          takeMVar mvar
 
 -- | Save a snapshot to disk and close the AcidState as a single atomic
 --   action. This is useful when you want to make sure that no events
 --   are saved to disk after a checkpoint.
-createCheckpointAndClose :: (SafeCopy st, Typeable st) => AcidState st -> IO ()
+createCheckpointAndClose :: (IsAcidic st, Typeable st) => AcidState st -> IO ()
 createCheckpointAndClose abstract_state
     = do mvar <- newEmptyMVar
          closeCore' (localCore acidState) $ \st ->
            do eventId <- askCurrentEntryId (localEvents acidState)
               pushAction (localEvents acidState) $
-                pushEntry (localCheckpoints acidState) (Checkpoint eventId (runPutLazy (safePut st))) (putMVar mvar ())
+                pushEntry (localCheckpoints acidState) (Checkpoint eventId st) (putMVar mvar ())
          takeMVar mvar
          closeFileLog (localEvents acidState)
          closeFileLog (localCheckpoints acidState)
@@ -207,75 +212,137 @@ createCheckpointAndClose abstract_state
   where acidState = downcast abstract_state
 
 
-data Checkpoint = Checkpoint EntryId ByteString
+data Checkpoint s = Checkpoint EntryId s
 
-instance SafeCopy Checkpoint where
+instance SafeCopy s => SafeCopy (Checkpoint s) where
     kind = primitive
     putCopy (Checkpoint eventEntryId content)
         = contain $
           do safePut eventEntryId
-             safePut content
-    getCopy = contain $ Checkpoint <$> safeGet <*> safeGet
+             safePut (runPutLazy (safePut content))
+    getCopy = contain $ Checkpoint <$> safeGet <*> (fromNested <$> safeGet)
+      where
+        fromNested b = case runGetLazy safeGet b of
+                         Left msg -> checkpointRestoreError msg
+                         Right v  -> v
 
 
 -- | Create an AcidState given an initial value.
 --
 --   This will create or resume a log found in the \"state\/[typeOf state]\/\" directory.
-openLocalState :: (Typeable st, IsAcidic st)
+openLocalState :: (Typeable st, IsAcidic st, SafeCopy st)
               => st                          -- ^ Initial state value. This value is only used if no checkpoint is
                                              --   found.
               -> IO (AcidState st)
 openLocalState initialState =
-  openLocalStateFrom ("state" </> show (typeOf initialState)) initialState
+  openLocalStateFrom (defaultStateDirectory initialState) initialState
 
 -- | Create an AcidState given an initial value.
 --
 --   This will create or resume a log found in the \"state\/[typeOf state]\/\" directory.
 --   The most recent checkpoint will be loaded immediately but the AcidState will not be opened
 --   until the returned function is executed.
-prepareLocalState :: (Typeable st, IsAcidic st)
+prepareLocalState :: (Typeable st, IsAcidic st, SafeCopy st)
                   => st                          -- ^ Initial state value. This value is only used if no checkpoint is
                                                  --   found.
                   -> IO (IO (AcidState st))
 prepareLocalState initialState =
-  prepareLocalStateFrom ("state" </> show (typeOf initialState)) initialState
+  prepareLocalStateFrom (defaultStateDirectory initialState) initialState
 
+-- | Directory to load the state from unless otherwise specified,
+-- namely \"state\/[typeOf state]\/\".
+defaultStateDirectory :: Typeable st => st -> FilePath
+defaultStateDirectory initialState = "state" </> show (typeOf initialState)
 
 -- | Create an AcidState given a log directory and an initial value.
 --
 --   This will create or resume a log found in @directory@.
 --   Running two AcidState's from the same directory is an error
 --   but will not result in dataloss.
-openLocalStateFrom :: (IsAcidic st)
+openLocalStateFrom :: (IsAcidic st, SafeCopy st)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
                                          --   found.
                   -> IO (AcidState st)
 openLocalStateFrom directory initialState =
-  join $ resumeLocalStateFrom directory initialState False
+  openLocalStateWithSerialiser directory initialState defaultSerialisationLayer
 
--- | Create an AcidState given an initial value.
+-- | Create an AcidState given a log directory, an initial value and a serialisation layer.
+--
+--   This will create or resume a log found in @directory@.
+--   Running two AcidState's from the same directory is an error
+--   but will not result in dataloss.
+openLocalStateWithSerialiser :: (IsAcidic st)
+                  => FilePath            -- ^ Location of the checkpoint and transaction files.
+                  -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
+                                         --   found.
+                  -> SerialisationLayer st -- ^ Serialisation layer to use for checkpoints, events and archives.
+                  -> IO (AcidState st)
+openLocalStateWithSerialiser directory initialState serialisationLayer =
+  join $ resumeLocalStateFrom directory initialState False serialisationLayer
+
+-- | Create an AcidState given a log directory and an initial value.
 --
 --   This will create or resume a log found in @directory@.
 --   The most recent checkpoint will be loaded immediately but the AcidState will not be opened
 --   until the returned function is executed.
-prepareLocalStateFrom :: (IsAcidic st)
+prepareLocalStateFrom :: (IsAcidic st, SafeCopy st)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
                                          --   found.
                   -> IO (IO (AcidState st))
 prepareLocalStateFrom directory initialState =
-  resumeLocalStateFrom directory initialState True
+  prepareLocalStateWithSerialiser directory initialState defaultSerialisationLayer
+
+-- | Create an AcidState given a log directory, an initial value and a serialisation layer.
+--
+--   This will create or resume a log found in @directory@.
+--   The most recent checkpoint will be loaded immediately but the AcidState will not be opened
+--   until the returned function is executed.
+prepareLocalStateWithSerialiser :: (IsAcidic st)
+                  => FilePath            -- ^ Location of the checkpoint and transaction files.
+                  -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
+                                         --   found.
+                  -> SerialisationLayer st -- ^ Serialisation layer to use for checkpoints, events and archives.
+                  -> IO (IO (AcidState st))
+prepareLocalStateWithSerialiser directory initialState serialisationLayer =
+  resumeLocalStateFrom directory initialState True serialisationLayer
 
 
+data SerialisationLayer st =
+    SerialisationLayer
+        {  checkpointSerialiser :: Serialiser (Checkpoint st)
+            -- ^ Serialisation strategy for checkpoints.
+            --
+            -- Use 'safeCopySerialiser' for the backwards-compatible
+            -- implementation using "Data.SafeCopy".
+
+        , eventSerialiser :: Serialiser (Tagged ByteString)
+            -- ^ Serialisation strategy for events.
+            --
+            -- Use 'safeCopySerialiser' for the backwards-compatible
+            -- implementation using "Data.SafeCopy".
+
+        , archiver :: Archiver
+            -- ^ Serialisation strategy for archive log files.
+            --
+            -- Use 'defaultArchiver' for the backwards-compatible
+            -- implementation using "Data.Serialize".
+        }
+
+-- | Standard (and historically the only) serialisation layer, using
+-- 'safeCopySerialiser' and 'defaultArchiver'.
+defaultSerialisationLayer :: SafeCopy st => SerialisationLayer st
+defaultSerialisationLayer = SerialisationLayer safeCopySerialiser safeCopySerialiser defaultArchiver
 
 resumeLocalStateFrom :: (IsAcidic st)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
                                          --   found.
                   -> Bool                -- ^ True => load checkpoint before acquiring the lock.
+                  -> SerialisationLayer st -- ^ Serialisation layer to use for checkpoints, events and archives.
                   -> IO (IO (AcidState st))
-resumeLocalStateFrom directory initialState delayLocking =
+resumeLocalStateFrom directory initialState delayLocking serialisationLayer =
   case delayLocking of
     True -> do
       (n, st) <- loadCheckpoint
@@ -290,18 +357,20 @@ resumeLocalStateFrom directory initialState delayLocking =
   where
     lockFile = directory </> "open"
     eventsLogKey = LogKey { logDirectory = directory
-                          , logPrefix = "events" }
+                          , logPrefix = "events"
+                          , logSerialiser = eventSerialiser serialisationLayer
+                          , logArchiver   = archiver serialisationLayer }
     checkpointsLogKey = LogKey { logDirectory = directory
-                               , logPrefix = "checkpoints" }
+                               , logPrefix = "checkpoints"
+                               , logSerialiser = checkpointSerialiser serialisationLayer
+                               , logArchiver = archiver serialisationLayer }
     loadCheckpoint = do
       mbLastCheckpoint <- Log.newestEntry checkpointsLogKey
       case mbLastCheckpoint of
         Nothing ->
           return (0, initialState)
-        Just (Checkpoint eventCutOff content) -> do
-          case runGetLazy safeGet content of
-            Left msg  -> checkpointRestoreError msg
-            Right val -> return (eventCutOff, val)
+        Just (Checkpoint eventCutOff val) ->
+          return (eventCutOff, val)
     replayEvents lock n st = do
       core <- mkCore (eventsToMethods acidEvents) st
 

--- a/src/Data/Acid/Log.hs
+++ b/src/Data/Acid/Log.hs
@@ -20,7 +20,8 @@ module Data.Acid.Log
     , archiveFileLog
     ) where
 
-import Data.Acid.Archive as Archive
+import Data.Acid.Archive (Archiver(..), Entries(..), entriesToList)
+import Data.Acid.Core
 import System.Directory
 import System.FilePath
 import System.IO
@@ -35,10 +36,6 @@ import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Unsafe as Strict
 import Data.List
 import Data.Maybe
-import qualified Data.Serialize.Get as Get
-import qualified Data.Serialize.Put as Put
-import Data.SafeCopy                             ( safePut, safeGet, SafeCopy )
-
 import Text.Printf                               ( printf )
 
 import Paths_acid_state                          ( version )
@@ -59,6 +56,8 @@ data LogKey object
     = LogKey
       { logDirectory :: FilePath
       , logPrefix    :: String
+      , logSerialiser :: Serialiser object
+      , logArchiver   :: Archiver
       }
 
 formatLogFile :: String -> EntryId -> String
@@ -89,7 +88,7 @@ openFileLog identifier = do
   queue <- newTVarIO ([], [])
   nextEntryRef <- newTVarIO 0
   tid1 <- myThreadId
-  tid2 <- forkIO $ fileWriter currentState queue tid1
+  tid2 <- forkIO $ fileWriter (logArchiver identifier) currentState queue tid1
   let fLog = FileLog { logIdentifier  = identifier
                      , logCurrent     = currentState
                      , logNextEntryId = nextEntryRef
@@ -100,15 +99,15 @@ openFileLog identifier = do
              handle <- open (logDirectory identifier </> formatLogFile (logPrefix identifier) currentEntryId)
              putMVar currentState handle
      else do let (lastFileEntryId, lastFilePath) = maximum logFiles
-             entries <- readEntities lastFilePath
+             entries <- readEntities (logArchiver identifier) lastFilePath
              let currentEntryId = lastFileEntryId + length entries
              atomically $ writeTVar nextEntryRef currentEntryId
              handle <- open (logDirectory identifier </> formatLogFile (logPrefix identifier) currentEntryId)
              putMVar currentState handle
   return fLog
 
-fileWriter :: MVar FHandle -> TVar ([Lazy.ByteString], [IO ()]) -> ThreadId -> IO ()
-fileWriter currentState queue parentTid = forever $ do
+fileWriter :: Archiver -> MVar FHandle -> TVar ([Lazy.ByteString], [IO ()]) -> ThreadId -> IO ()
+fileWriter archiver currentState queue parentTid = forever $ do
   (entries, actions) <- atomically $ do
     (entries, actions) <- readTVar queue
     when (null entries && null actions) retry
@@ -116,7 +115,7 @@ fileWriter currentState queue parentTid = forever $ do
     return (reverse entries, reverse actions)
   handle (\e -> throwTo parentTid (e :: IOException)) $
     withMVar currentState $ \fd -> do
-      let arch = Archive.packEntries entries
+      let arch = archiveWrite archiver entries
       writeToDisk fd (repack arch)
   sequence_ actions
   yield
@@ -150,14 +149,10 @@ closeFileLog fLog =
     _ <- forkIO $ forM_ (logThreads fLog) killThread
     return $ error "FileLog has been closed"
 
-readEntities :: FilePath -> IO [Lazy.ByteString]
-readEntities path = do
+readEntities :: Archiver -> FilePath -> IO [Lazy.ByteString]
+readEntities archiver path = do
   archive <- Lazy.readFile path
-  return $ worker (Archive.readEntries archive)
- where
-  worker Done              = []
-  worker (Next entry next) = entry : worker next
-  worker (Fail msg)        = error msg
+  return $ entriesToList (archiveRead archiver archive)
 
 ensureLeastEntryId :: FileLog object -> EntryId -> IO ()
 ensureLeastEntryId fLog youngestEntry = do
@@ -170,7 +165,7 @@ ensureLeastEntryId fLog youngestEntry = do
 -- Read all durable entries younger than the given EntryId.
 -- Note that entries written during or after this call won't
 -- be included in the returned list.
-readEntriesFrom :: SafeCopy object => FileLog object -> EntryId -> IO [object]
+readEntriesFrom :: FileLog object -> EntryId -> IO [object]
 readEntriesFrom fLog youngestEntry = do
   -- Cut the log so we can read written entries without interfering
   -- with the writing of new entries.
@@ -186,15 +181,16 @@ readEntriesFrom fLog youngestEntry = do
   -- cereal-0.3.5.2 and binary-0.7.1.0. The code should revert back
   -- to lazy bytestrings once the bug has been fixed.
   archive <- liftM Lazy.fromChunks $ mapM (Strict.readFile . snd) relevant
-  let entries = entriesToList $ readEntries archive
-  return $ map decode'
+  let entries = entriesToList $ archiveRead (logArchiver identifier) archive
+  return $ map (decode' identifier)
          $ take (entryCap - youngestEntry)             -- Take events under the eventCap.
          $ drop (youngestEntry - firstEntryId) entries -- Drop entries that are too young.
  where
   rangeStart (firstEntryId, _path) = firstEntryId
+  identifier = logIdentifier fLog
 
 -- Obliterate log entries younger than or equal to the EventId. Very unsafe, can't be undone
-rollbackTo :: SafeCopy object => LogKey object -> EntryId -> IO ()
+rollbackTo :: LogKey object -> EntryId -> IO ()
 rollbackTo identifier youngestEntry = do
   logFiles <- findLogFiles identifier
   let sorted = sort logFiles
@@ -204,24 +200,24 @@ rollbackTo identifier youngestEntry = do
         | otherwise = do
             archive <- Strict.readFile path
             pathHandle <- openFile path WriteMode
-            let entries = entriesToList $ readEntries (Lazy.fromChunks [archive])
+            let entries = entriesToList $ archiveRead (logArchiver identifier) (Lazy.fromChunks [archive])
                 entriesToKeep = take (youngestEntry - rangeStart + 1) entries
-                lengthToKeep = Lazy.length (packEntries entriesToKeep)
+                lengthToKeep = Lazy.length (archiveWrite (logArchiver identifier) entriesToKeep)
             hSetFileSize pathHandle (fromIntegral lengthToKeep)
             hClose pathHandle
   loop (reverse sorted)
 
 -- Obliterate log entries as long as the filterFn returns True.
-rollbackWhile :: SafeCopy object => LogKey object -> (object -> Bool) -> IO ()
+rollbackWhile :: LogKey object -> (object -> Bool) -> IO ()
 rollbackWhile identifier filterFn = do
   logFiles <- findLogFiles identifier
   let sorted = sort logFiles
       loop [] = return ()
       loop ((_rangeStart, path) : xs) = do
         archive <- Strict.readFile path
-        let entries = entriesToList $ readEntries (Lazy.fromChunks [archive])
-            entriesToSkip = takeWhile (filterFn . decode') $ reverse entries
-            skip_size = Lazy.length (packEntries entriesToSkip)
+        let entries = entriesToList $ archiveRead (logArchiver identifier) (Lazy.fromChunks [archive])
+            entriesToSkip = takeWhile (filterFn . decode' identifier) $ reverse entries
+            skip_size = Lazy.length (archiveWrite (logArchiver identifier) entriesToSkip)
             orig_size = fromIntegral $ Strict.length archive
             new_size = orig_size - skip_size
         if new_size == 0
@@ -294,7 +290,7 @@ cutFileLog fLog = do
 -- Implementation: Search the newest log files first. Once a file
 --                 containing at least one valid entry is found,
 --                 return the last entry in that file.
-newestEntry :: SafeCopy object => LogKey object -> IO (Maybe object)
+newestEntry :: LogKey object -> IO (Maybe object)
 newestEntry identifier = do
   logFiles <- findLogFiles identifier
   let sorted = reverse $ sort logFiles
@@ -307,9 +303,9 @@ newestEntry identifier = do
     -- cereal-0.3.5.2 and binary-0.7.1.0. The code should revert back
     -- to lazy bytestrings once the bug has been fixed.
     archive <- fmap Lazy.fromStrict $ Strict.readFile logFile
-    case Archive.readEntries archive of
+    case archiveRead (logArchiver identifier) archive of
       Done            -> worker logFiles
-      Next entry next -> return $ Just (decode' (lastEntry entry next))
+      Next entry next -> return $ Just (decode' identifier (lastEntry entry next))
       Fail msg        -> error msg
   lastEntry entry Done          = entry
   lastEntry entry (Fail msg)    = error msg
@@ -318,14 +314,15 @@ newestEntry identifier = do
 -- Schedule a new log entry. This call does not block
 -- The given IO action runs once the object is durable. The IO action
 -- blocks the serialization of events so it should be swift.
-pushEntry :: SafeCopy object => FileLog object -> object -> IO () -> IO ()
+pushEntry :: FileLog object -> object -> IO () -> IO ()
 pushEntry fLog object finally = atomically $ do
   tid <- readTVar (logNextEntryId fLog)
   writeTVar (logNextEntryId fLog) (tid+1)
   (entries, actions) <- readTVar (logQueue fLog)
   writeTVar (logQueue fLog) ( encoded : entries, finally : actions )
  where
-  encoded = Lazy.fromChunks [ Strict.copy $ Put.runPut (safePut object) ]
+  encoded = Lazy.fromChunks [ Strict.copy $ Lazy.toStrict $
+              serialiserEncode (logSerialiser (logIdentifier fLog)) object ]
 
 -- The given IO action is executed once all previous entries are durable.
 pushAction :: FileLog object -> IO () -> IO ()
@@ -339,8 +336,8 @@ askCurrentEntryId fLog = atomically $
 
 
 -- FIXME: Check for unused input.
-decode' :: SafeCopy object => Lazy.ByteString -> object
-decode' inp =
-  case Get.runGetLazy safeGet inp of
+decode' :: LogKey object -> Lazy.ByteString -> object
+decode' s inp =
+  case serialiserDecode (logSerialiser s) inp of
     Left msg  -> error msg
     Right val -> val

--- a/src/Data/Acid/Memory.hs
+++ b/src/Data/Acid/Memory.hs
@@ -24,8 +24,6 @@ import Data.ByteString.Lazy           ( ByteString )
 import Data.Typeable                  ( Typeable )
 import Data.IORef                     ( IORef, newIORef, readIORef, writeIORef )
 
-import Data.SafeCopy                  ( SafeCopy(..) )
-
 
 {-| State container offering full ACID (Atomicity, Consistency, Isolation and Durability)
     guarantees.
@@ -103,12 +101,12 @@ memoryQueryCold acidState event
     where coldMethod = lookupColdMethod (localCore acidState) event
 
 -- | This is a nop with the memory backend.
-createMemoryCheckpoint :: SafeCopy st => MemoryState st -> IO ()
+createMemoryCheckpoint :: MemoryState st -> IO ()
 createMemoryCheckpoint acidState
     = return ()
 
 -- | This is a nop with the memory backend.
-createMemoryArchive :: SafeCopy st => MemoryState st -> IO ()
+createMemoryArchive :: MemoryState st -> IO ()
 createMemoryArchive acidState
     = return ()
 


### PR DESCRIPTION
Fixes #88. This parameterises `acid-state` over the underlying serialisation layer, so it is possible to swap out `cereal`/`safecopy` for something else. The major changes are as follows:

 * The `IsAcidic` class no longer has `SafeCopy` as a superclass.  Instead, the `SafeCopy` constraint is introduced when opening a local state.  There are new functions such as `openLocalStateWithSerialiser` that make it possible to supply a `SerialisationLayer` explicitly, which is an interface describing how to serialise archives, checkpoints and events (i.e. method-name-tagged bytestrings), but not the method arguments or result.

 * Similarly, the `Method` class no longer has any superclasses (including `Typeable`, see #57).

 * The `UpdateEvent` and `QueryEvent` constructors now take an additional argument, a `MethodSerialiser` that describes how to serialise the method arguments and result. Hand-written `IsAcidic` instances will need to be modified to insert a call to `safeCopyMethodSerialiser`.  Correspondingly, the `Method` constructor of `MethodContainer` also carries a `MethodSerialiser`.

 * Most users will have their `IsAcidic` instances generated by Template Haskell, in which case no change to user code should be necessary. The TH code has been extended with a new function `makeAcidicWithSerialiser` allowing different method serialisers to be used.

 * The `Checkpoint` type is now parameterised over the type of the state, rather than it already being encoded to a bytestring. This makes it possible to remove a layer of bytestring packing in the serialised representation. I believe the adapted `SafeCopy` instance should be backwards-compatible, but this needs further testing.

 * Various other minor API changes to pass around serialisers and reflect the changes to superclass constraints.  These are mostly in notionally-internal code, so I don't expect them to have much impact on most users.

I'd appreciate feedback on whether the approach taken here looks reasonable. This branch still needs further tests before it gets merged. I'll be away on holiday next week, but I'll look to make further progress after that.

Next steps:

 * Add tests, including that the existing serialisation format has not changed, and try to benchmark the performance impact of these changes.

 * Update the changelog and document the migration steps required for non-TH users.

 * Factor out a separate package for the core `acid-state` functionality, say `acid-state-internal`. I'm inclined to do this by moving files in this repo into two subdirectories, one for each package.

 * Publish a library using this functionality to support CBOR-based serialisation, tentatively named `acid-state-cbor`. Should this live in this repo, in a separate repo under the `acid-state` GH organization, or should it be completely separate?

cc @stepcut, @dcoutts