### PR TITLE
Rename lock file back to open.lock

### DIFF
--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -288,7 +288,7 @@ resumeLocalStateFrom directory initialState delayLocking =
       return $ do
         replayEvents lock n st
   where
-    lockFile = directory </> "open"
+    lockFile = directory </> "open.lock"
     eventsLogKey = LogKey { logDirectory = directory
                           , logPrefix = "events" }
     checkpointsLogKey = LogKey { logDirectory = directory


### PR DESCRIPTION
This was the old name of the file, before the change to the filelock library in 550d8703ac37595e9594d06e5a77e5884f64f7f2 changed it to just "open", which broke the benchmarks.