### PR TITLE
Fix a memory leak in pushEntry

### DIFF
--- a/src/Data/Acid/Log.hs
+++ b/src/Data/Acid/Log.hs
@@ -321,7 +321,7 @@ newestEntry identifier = do
 pushEntry :: SafeCopy object => FileLog object -> object -> IO () -> IO ()
 pushEntry fLog object finally = atomically $ do
   tid <- readTVar (logNextEntryId fLog)
-  writeTVar (logNextEntryId fLog) (tid+1)
+  writeTVar (logNextEntryId fLog) $! tid+1
   (entries, actions) <- readTVar (logQueue fLog)
   writeTVar (logQueue fLog) ( encoded : entries, finally : actions )
  where


### PR DESCRIPTION
Fixes #103, I think. @edsko is it easy for you to check if this commit solves your original problem? Here are [before](https://github.com/acid-state/acid-state/files/2404720/leak-h.pdf) and [after](https://github.com/acid-state/acid-state/files/2404721/leak-fixed.pdf) profiles of a cut-down version on my machine.

Irrespective of the leak, the test program seems to run very slowly for me. I'm not sure if that is to be expected.

