### PR TITLE
Incorporate ChangeState example into testsuite and add another example

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -13,10 +13,6 @@ Cabal-version:       >=1.10
 tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3
 Extra-source-files:
         CHANGELOG.md
-        examples/*.hs
-        examples/errors/*.hs
-        src-win32/*.hs
-        src-unix/*.hs
         test-state/OldStateTest1/*.log
         test-state/OldStateTest1/*.version
         test-state/OldStateTest2/*.log

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -124,9 +124,11 @@ test-suite examples
                      , mtl
                      , network
                      , safecopy
+                     , text
                      , time
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   other-modules:       ChangeState
+                       ChangeVersion
                        CheckpointCutsEvent
                        Exceptions
                        HelloDatabase

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -130,7 +130,8 @@ test-suite examples
                      , safecopy
                      , time
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  other-modules:       CheckpointCutsEvent
+  other-modules:       ChangeState
+                       CheckpointCutsEvent
                        Exceptions
                        HelloDatabase
                        HelloWorld

--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified ChangeState
+import qualified ChangeVersion
 import qualified CheckpointCutsEvent
 import qualified Exceptions
 import qualified RemoveEvent
@@ -9,6 +10,7 @@ import qualified SlowCheckpoint
 main :: IO ()
 main = do
   ChangeState.test
+  ChangeVersion.test
   CheckpointCutsEvent.main
   Exceptions.test
   RemoveEvent.test

--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import qualified ChangeState
 import qualified CheckpointCutsEvent
 import qualified Exceptions
 import qualified RemoveEvent
@@ -7,6 +8,7 @@ import qualified SlowCheckpoint
 
 main :: IO ()
 main = do
+  ChangeState.test
   CheckpointCutsEvent.main
   Exceptions.test
   RemoveEvent.test

--- a/examples/errors/ChangeState.hs
+++ b/examples/errors/ChangeState.hs
@@ -1,21 +1,15 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
-module Main (main) where
+module ChangeState (main, test) where
 
 import           Data.Acid
 
+import           Control.Exception
 import           Control.Monad.State
 import           Data.SafeCopy
+import           System.Directory
 import           System.Environment
-
-import           Data.Typeable
-
-import           Control.Exception
-import           Prelude             hiding (catch)
-
-import qualified Data.Text           as Text
 
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
@@ -23,11 +17,14 @@ import qualified Data.Text           as Text
 data FirstState = FirstState String
     deriving (Show)
 
-data SecondState = SecondState Text.Text
+data SecondState = SecondState Int
     deriving (Show)
 
 $(deriveSafeCopy 0 'base ''FirstState)
-$(deriveSafeCopy 0 'base ''SecondState)
+$(deriveSafeCopy 1 'base ''SecondState)
+-- The version number difference is important here, as safecopy has no
+-- way to notice if we change a type and fail to update its migration
+-- history.
 
 ------------------------------------------------------
 -- The transaction we will execute over the state.
@@ -43,9 +40,24 @@ main = do putStrLn "This example simulates what happens when you modify your sta
           putStrLn "without telling AcidState how to migrate from the old version to the new."
           putStrLn "Hopefully this program will fail with a readable error message."
           putStrLn ""
-          firstAcid <- openLocalStateFrom "state/ChangeState" (FirstState "first state")
+          firstAcid <- openLocalStateFrom fp (FirstState "first state")
           createCheckpoint firstAcid
           closeAcidState firstAcid
-          secondAcid <- openLocalStateFrom "state/ChangeState" (SecondState (Text.pack "This initial value shouldn't be used"))
+          secondAcid <- openLocalStateFrom fp (SecondState 42)
           closeAcidState secondAcid
-          putStrLn "If you see this message then something has gone wrong!"
+          error "If you see this message then something has gone wrong!"
+
+test :: IO ()
+test = do
+    putStrLn "ChangeState test"
+    exists <- doesDirectoryExist fp
+    when exists $ removeDirectoryRecursive fp
+    handle hdl main
+    putStrLn "ChangeState done"
+  where
+    hdl (ErrorCall msg)
+      | msg == "Could not parse saved checkpoint due to the following error: Failed reading: safecopy: ChangeState.SecondState: Cannot find getter associated with this version number: Version {unVersion = 0}\nEmpty call stack\n"
+      = putStrLn $ "Caught error: " ++ msg
+    hdl e = throwIO e
+
+fp = "state/ChangeState"

--- a/examples/errors/ChangeVersion.hs
+++ b/examples/errors/ChangeVersion.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
-module ChangeState (main, test) where
+module ChangeVersion (main, test) where
 
 import           Data.Acid
 
@@ -11,19 +11,22 @@ import           Data.SafeCopy
 import           System.Directory
 import           System.Environment
 
-import qualified Data.Text           as Text
-
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
 
 data FirstState = FirstState String
     deriving (Show)
 
-data SecondState = SecondState Text.Text
+data SecondState = SecondState Int
     deriving (Show)
 
 $(deriveSafeCopy 0 'base ''FirstState)
-$(deriveSafeCopy 0 'base ''SecondState)
+$(deriveSafeCopy 1 'base ''SecondState)
+-- The version number difference is important here, as safecopy has no
+-- way to reliably notice if we change a type and fail to update its
+-- migration history.  In some cases the serialised data will fail to
+-- parse (see the "ChangeState" example), but it depends on the types
+-- involved, and this will not always be the case.
 
 ------------------------------------------------------
 -- The transaction we will execute over the state.
@@ -35,28 +38,28 @@ $(makeAcidic ''SecondState [])
 -- This is how AcidState is used:
 
 main :: IO ()
-main = do putStrLn "This example simulates what happens when you modify your state type"
-          putStrLn "without telling AcidState how to migrate from the old version to the new."
+main = do putStrLn "This example simulates what happens when you modify your safecopy"
+          putStrLn "version without specifying how to migrate from the old version to the new."
           putStrLn "Hopefully this program will fail with a readable error message."
           putStrLn ""
           firstAcid <- openLocalStateFrom fp (FirstState "first state")
           createCheckpoint firstAcid
           closeAcidState firstAcid
-          secondAcid <- openLocalStateFrom fp (SecondState (Text.pack "This initial value shouldn't be used"))
+          secondAcid <- openLocalStateFrom fp (SecondState 42)
           closeAcidState secondAcid
           error "If you see this message then something has gone wrong!"
 
 test :: IO ()
 test = do
-    putStrLn "ChangeState test"
+    putStrLn "ChangeVersion test"
     exists <- doesDirectoryExist fp
     when exists $ removeDirectoryRecursive fp
     handle hdl main
-    putStrLn "ChangeState done"
+    putStrLn "ChangeVersion done"
   where
     hdl (ErrorCall msg)
-      | msg == "Could not parse saved checkpoint due to the following error: too few bytes\nFrom:\tChangeState.SecondState:\n\tdemandInput\n\n"
+      | msg == "Could not parse saved checkpoint due to the following error: Failed reading: safecopy: ChangeVersion.SecondState: Cannot find getter associated with this version number: Version {unVersion = 0}\nEmpty call stack\n"
       = putStrLn $ "Caught error: " ++ msg
     hdl e = throwIO e
 
-fp = "state/ChangeState"
+fp = "state/ChangeVersion"


### PR DESCRIPTION
Fixes #102. ~~I don't think the old `ChangeState` example could reasonably work reliably, given the limitations of `safecopy`, which IIUC looks only at version numbers (not type names) and can't tell if the definition of a type has changed unless corresponding changes have been made to the version history. Since this isn't really an `acid-state` issue per se, I've adapted the example into something that fails predictably.~~

EDIT: I've amended this to restore the original example and add another, per discussion on #102.