### PR TITLE
Enable Windows CI on AppVeyor

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -48,7 +48,6 @@ Library
                        bytestring >= 0.10.2,
                        cereal >= 0.4.1.0,
                        containers,
-                       extensible-exceptions,
                        safecopy >= 0.6,
                        stm >= 2.4,
                        directory,

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -137,7 +137,6 @@ test-suite examples
                        KeyValueNoTH
                        MonadStateConstraint
                        ParameterisedState
-                       Proxy
                        RemoteClient
                        RemoteCommon
                        RemoteServer
@@ -145,6 +144,8 @@ test-suite examples
                        SlowCheckpoint
                        StressTest
                        StressTestNoTH
+  if !os(windows)
+     other-modules:    Proxy
   default-language:    Haskell2010
 
 benchmark loading-benchmark

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+clone_folder: "c:\\WORK"
+
+environment:
+  global:
+    CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http"
+  matrix:
+    - GHCVER: "8.4.4"
+      CHOCOPTS:
+      TEST: --enable-tests
+      BENCH: --enable-benchmarks
+    - GHCVER: "8.2.2"
+      CHOCOPTS:
+      TEST: --enable-tests
+      BENCH: --enable-benchmarks
+    - GHCVER: "8.0.2.2"
+      CHOCOPTS:
+      TEST: --disable-tests
+      BENCH: --disable-benchmarks
+    - GHCVER: "7.10.3.2"
+      CHOCOPTS:
+      TEST: --disable-tests
+      BENCH: --disable-benchmarks
+    - GHCVER: "7.8.4.1"
+      CHOCOPTS:
+      TEST: --disable-tests
+      BENCH: --disable-benchmarks
+    - GHCVER: "7.6.3.1"
+      CHOCOPTS:
+      TEST: --disable-tests
+      BENCH: --disable-benchmarks
+
+cache:
+- "C:\\SR"
+
+install:
+ - "choco install -y ghc --version %GHCVER% %CHOCOPTS%"
+ - "choco install -y cabal %CHOCOPTS%"
+ - "refreshenv"
+ - "set PATH=C:\\ghc\\ghc-%GHCVER%:C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin;%PATH%"
+ - "cabal --version"
+ - "ghc --version"
+ - "cabal %CABOPTS% update -v"
+
+build: off
+
+test_script:
+ - "echo packages:. > cabal.project"
+ - "cabal %CABOPTS% new-build %TEST% %BENCH% -j1 all"
+ # state-machine test and the benchmarks currently fail as they assume POSIX file semantics
+ - if [%TEST%]==[--enable-tests] cabal %CABOPTS% new-test -f +skip-state-machine-test
+ # - if [%BENCH%]==[--enable-benchmarks] cabal %CABOPTS% new-bench

--- a/src-win32/FileIO.hs
+++ b/src-win32/FileIO.hs
@@ -11,18 +11,8 @@ import System.Win32(HANDLE,
 import Data.Word(Word8,Word32)
 import Foreign(Ptr)
 import System.IO
-import System.Directory(createDirectoryIfMissing,removeFile)
-import Control.Exception.Extensible(try,throw)
-import Control.Exception(SomeException,IOException)
-import qualified Control.Exception as E
 
 data FHandle = FHandle HANDLE
-
-tryE :: IO a -> IO (Either SomeException a)
-tryE = try
-
-catchIO :: IO a -> (IOException -> IO a) -> IO a
-catchIO = E.catch
 
 open :: FilePath -> IO FHandle
 open filename =
@@ -36,7 +26,3 @@ flush (FHandle handle) = flushFileBuffers handle
 
 close :: FHandle -> IO ()
 close (FHandle handle) = closeHandle handle
-
--- Windows opens files for exclusive writing by default
-openExclusively :: FilePath -> IO Handle
-openExclusively fp = openFile fp ReadWriteMode


### PR DESCRIPTION
This configures CI on Windows using AppVeyor. It is currently enabled on [my fork](https://ci.appveyor.com/project/adamgundry/acid-state) but will need someone with privileges over the `acid-state` GitHub organization to enable AppVeyor for this repo.

While doing this I discovered some dead code on WIndows, which I've removed.