### PR TITLE
Better Errors

### DIFF
--- a/examples/errors/ChangeState.hs
+++ b/examples/errors/ChangeState.hs
@@ -10,6 +10,7 @@ import           Control.Monad.State
 import           Data.SafeCopy
 import           System.Directory
 import           System.Environment
+import           Data.List (isSuffixOf)
 
 import qualified Data.Text           as Text
 
@@ -55,7 +56,7 @@ test = do
     putStrLn "ChangeState done"
   where
     hdl (ErrorCall msg)
-      | msg == "Could not parse saved checkpoint due to the following error: too few bytes\nFrom:\tChangeState.SecondState:\n\tdemandInput\n\n"
+      | "Could not parse saved checkpoint due to the following error: too few bytes\nFrom:\tChangeState.SecondState:\n\tdemandInput\n\n" `isSuffixOf` msg 
       = putStrLn $ "Caught error: " ++ msg
     hdl e = throwIO e
 

--- a/examples/errors/RemoveEvent.hs
+++ b/examples/errors/RemoveEvent.hs
@@ -10,6 +10,7 @@ import           Control.Monad.State
 import           Data.SafeCopy
 import           System.Directory
 import           System.Environment
+import           Data.List (isSuffixOf)
 
 import           Data.Typeable
 
@@ -62,7 +63,7 @@ test = do
     putStrLn "RemoveEvent done"
   where
     hdl (ErrorCall msg)
-      | msg == "This method is required but not available: \"RemoveEvent.FirstEvent\". Did you perhaps remove it before creating a checkpoint?"
+      | "This method is required but not available: \"RemoveEvent.FirstEvent\". Did you perhaps remove it before creating a checkpoint?" `isSuffixOf` msg
       = putStrLn $ "Caught error: " ++ msg
     hdl e = throwIO e
 

--- a/src/Data/Acid/Abstract.hs
+++ b/src/Data/Acid/Abstract.hs
@@ -132,7 +132,7 @@ downcast AcidState{acidSubState = AnyState sub}
          Just (Just x) -> x
          _ ->
            error $
-            "Data.Acid: Invalid subtype cast: " ++ show (typeOf sub) ++ " -> " ++ show (typeOf r)
+            "Data.Acid.Abstract: Invalid subtype cast: " ++ show (typeOf sub) ++ " -> " ++ show (typeOf r)
 #else
 downcast :: Typeable1 sub => AcidState st -> sub st
 downcast AcidState{acidSubState = AnyState sub}
@@ -142,5 +142,5 @@ downcast AcidState{acidSubState = AnyState sub}
          Just (Just x) -> x
          _ ->
            error $
-            "Data.Acid: Invalid subtype cast: " ++ show (typeOf1 sub) ++ " -> " ++ show (typeOf1 r)
+            "Data.Acid.Abstract: Invalid subtype cast: " ++ show (typeOf1 sub) ++ " -> " ++ show (typeOf1 r)
 #endif

--- a/src/Data/Acid/Archive.hs
+++ b/src/Data/Acid/Archive.hs
@@ -30,7 +30,7 @@ data Entries = Done | Next Entry Entries | Fail String
 entriesToList :: Entries -> [Entry]
 entriesToList Done              = []
 entriesToList (Next entry next) = entry : entriesToList next
-entriesToList (Fail msg)        = error msg
+entriesToList (Fail msg)        = error $ "Data.Acid.Archive: " <> msg
 
 entriesToListNoFail :: Entries -> [Entry]
 entriesToListNoFail Done              = []

--- a/src/Data/Acid/Core.hs
+++ b/src/Data/Acid/Core.hs
@@ -40,6 +40,7 @@ import Control.Concurrent                 ( MVar, newMVar, withMVar
 import Control.Monad                      ( liftM )
 import Control.Monad.State                ( State, runState )
 import qualified Data.Map as Map
+import Data.Monoid                        ((<>))
 import Data.ByteString.Lazy as Lazy       ( ByteString )
 import Data.ByteString.Lazy.Char8 as Lazy ( pack, unpack )
 
@@ -117,7 +118,7 @@ closeCore' core action
     = modifyMVar_ (coreState core) $ \st ->
       do action st
          return errorMsg
-    where errorMsg = error "Access failure: Core closed."
+    where errorMsg = error "Data.Acid.Core: Access failure: Core closed."
 
 -- | Modify the state component. The resulting state is ensured to be in
 --   WHNF.
@@ -160,12 +161,12 @@ lookupColdMethod core (storedMethodTag, methodContent)
 lazyDecode :: SafeCopy a => Lazy.ByteString -> a
 lazyDecode inp
     = case runGetLazy safeGet inp of
-        Left msg  -> error msg
+        Left msg  -> error $ "Data.Acid.Core: " <> msg
         Right val -> val
 
 missingMethod :: Tag -> a
 missingMethod tag
-    = error msg
+    = error $ "Data.Acid.Core: " <> msg
     where msg = "This method is required but not available: " ++ show (Lazy.unpack tag) ++
                 ". Did you perhaps remove it before creating a checkpoint?"
 

--- a/src/Data/Acid/Remote.hs
+++ b/src/Data/Acid/Remote.hs
@@ -108,6 +108,7 @@ import Control.Concurrent.Chan                       ( newChan, readChan, writeC
 import Data.Acid.Abstract
 import Data.Acid.Core
 import Data.Acid.Common
+import Data.Monoid                                   ((<>))
 import qualified Data.ByteString                     as Strict
 import Data.ByteString.Char8                         ( pack )
 import qualified Data.ByteString.Lazy                as Lazy
@@ -291,7 +292,7 @@ instance Serialize Command where
              1 -> liftM RunUpdate get
              2 -> return CreateCheckpoint
              3 -> return CreateArchive
-             _ -> error $ "Serialize.get for Command, invalid tag: " ++ show tag
+             _ -> error $ "Data.Acid.Remote: Serialize.get for Command, invalid tag: " ++ show tag
 
 data Response = Result Lazy.ByteString | Acknowledgement | ConnectionError
 
@@ -305,7 +306,7 @@ instance Serialize Response where
              0 -> liftM Result get
              1 -> return Acknowledgement
              2 -> return ConnectionError
-             _ -> error $ "Serialize.get for Response, invalid tag: " ++ show tag
+             _ -> error $ "Data.Acid.Remote: Serialize.get for Response, invalid tag: " ++ show tag
 
 {- | Server inner-loop
 
@@ -429,7 +430,7 @@ processRemoteState reconnect
                  getResponse leftover =
                      do debugStrLn $ "listener: listening for Response."
                         let go inp = case inp of
-                                   Fail msg _     -> error msg
+                                   Fail msg _     -> error $ "Data.Acid.Remote: " <> msg
                                    Partial cont   -> do debugStrLn $ "listener: ccGetSome"
                                                         bs <- ccGetSome cc 1024
                                                         go (cont bs)
@@ -487,7 +488,7 @@ remoteQuery acidState event
   = do let encoded = runPutLazy (safePut event)
        resp <- remoteQueryCold acidState (methodTag event, encoded)
        return (case runGetLazyFix safeGet resp of
-                 Left msg -> error msg
+                 Left msg -> error $ "Data.Acid.Remote: " <> msg
                  Right result -> result)
 
 remoteQueryCold :: RemoteState st -> Tagged Lazy.ByteString -> IO Lazy.ByteString
@@ -497,7 +498,7 @@ remoteQueryCold rs@(RemoteState fn _shutdown) event
          (Result result) -> return result
          ConnectionError -> do debugStrLn "retrying query event."
                                remoteQueryCold rs event
-         Acknowledgement    -> error "remoteQueryCold got Acknowledgement. That should never happen."
+         Acknowledgement    -> error "Data.Acid.Remote: remoteQueryCold got Acknowledgement. That should never happen."
 
 scheduleRemoteUpdate :: UpdateEvent event => RemoteState (EventState event) -> event -> IO (MVar (EventResult event))
 scheduleRemoteUpdate (RemoteState fn _shutdown) event
@@ -506,7 +507,7 @@ scheduleRemoteUpdate (RemoteState fn _shutdown) event
        respRef <- fn (RunUpdate (methodTag event, encoded))
        forkIO $ do Result resp <- takeMVar respRef
                    putMVar parsed (case runGetLazyFix safeGet resp of
-                                      Left msg -> error msg
+                                      Left msg -> error $ "Data.Acid.Remote: " <> msg
                                       Right result -> result)
        return parsed
 


### PR DESCRIPTION
It's too difficult to figure out the source, if a runtime exception is caused by the call to `error` function through a third party library.
Acid-state also calls error function frequently at many places.
A simple solution would be to add identifying info (module names) to the error message, which will help in debugging process.