### PR TITLE
Run CI on GHC 8.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-8.6.3"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -10,7 +10,7 @@ Maintainer:          Lemmih <lemmih@gmail.com>
 Category:            Database
 Build-type:          Simple
 Cabal-version:       >=1.10
-tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3
+tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.3
 Extra-source-files:
         CHANGELOG.md
         test-state/OldStateTest1/*.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,22 +16,22 @@ environment:
       CHOCOPTS:
       TEST: --enable-tests
       BENCH: --enable-benchmarks
-    - GHCVER: "8.0.2.2"
-      CHOCOPTS:
-      TEST: --disable-tests
-      BENCH: --disable-benchmarks
-    - GHCVER: "7.10.3.2"
-      CHOCOPTS:
-      TEST: --disable-tests
-      BENCH: --disable-benchmarks
-    - GHCVER: "7.8.4.1"
-      CHOCOPTS:
-      TEST: --disable-tests
-      BENCH: --disable-benchmarks
-    - GHCVER: "7.6.3.1"
-      CHOCOPTS:
-      TEST: --disable-tests
-      BENCH: --disable-benchmarks
+    # - GHCVER: "8.0.2.2"
+    #   CHOCOPTS:
+    #   TEST: --disable-tests
+    #   BENCH: --disable-benchmarks
+    # - GHCVER: "7.10.3.2"
+    #   CHOCOPTS:
+    #   TEST: --disable-tests
+    #   BENCH: --disable-benchmarks
+    # - GHCVER: "7.8.4.1"
+    #   CHOCOPTS:
+    #   TEST: --disable-tests
+    #   BENCH: --disable-benchmarks
+    # - GHCVER: "7.6.3.1"
+    #   CHOCOPTS:
+    #   TEST: --disable-tests
+    #   BENCH: --disable-benchmarks
 
 cache:
 - "C:\\SR"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,10 @@ environment:
   global:
     CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http"
   matrix:
-    - GHCVER: "8.6.3"
-      CHOCOPTS:
-      TEST: --enable-tests
-      BENCH: --enable-benchmarks
+    # - GHCVER: "8.6.3"
+    #   CHOCOPTS:
+    #   TEST: --enable-tests
+    #   BENCH: --enable-benchmarks
     - GHCVER: "8.4.4"
       CHOCOPTS:
       TEST: --enable-tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ environment:
   global:
     CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http"
   matrix:
+    - GHCVER: "8.6.3"
+      CHOCOPTS:
+      TEST: --enable-tests
+      BENCH: --enable-benchmarks
     - GHCVER: "8.4.4"
       CHOCOPTS:
       TEST: --enable-tests


### PR DESCRIPTION
I've also disabled AppVeyor on GHC 8.0 and earlier, because it takes a long time. We still have CI back to 7.6 on Travis.