### PR TITLE
Remove additional bytestring conversion.

### DIFF
--- a/src/Data/Acid/Log.hs
+++ b/src/Data/Acid/Log.hs
@@ -322,8 +322,7 @@ pushEntry fLog object finally = atomically $ do
   (entries, actions) <- readTVar (logQueue fLog)
   writeTVar (logQueue fLog) ( encoded : entries, finally : actions )
  where
-  encoded = Lazy.fromChunks [ Strict.copy $ Lazy.toStrict $
-              serialiserEncode (logSerialiser (logIdentifier fLog)) object ]
+  encoded = serialiserEncode (logSerialiser (logIdentifier fLog)) object
 
 -- The given IO action is executed once all previous entries are durable.
 pushAction :: FileLog object -> IO () -> IO ()


### PR DESCRIPTION
When performing a checkpoint, the state size gets very large. I think the additional `Bytestring` copying is to blame.