### PR TITLE
Add a repair tool for WAL and checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,7 @@ FAQ
 
 Robustness
 ================
+  - How do I recover a corrupted acid-state database?
+    - acid-state provides an `acid-state-repair` tool. Build it with `stack build` in the root of this repository, you can then call `acid-state-repair` from a directory holding a corrupted database to repair it. In most case it should only drop the last entry, presumably a partial write because of a crash, but if the base is heavily corrupted, it may restore the database to an older state. Your database is always saved in `.bak` files, so that the repair operation is reversible.
   - How well does acid-state deal with errors? 
     - List of Error Scenarios.

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -39,6 +39,7 @@ Library
                        Data.Acid.Log, Data.Acid.CRC,
                        Data.Acid.Abstract, Data.Acid.Core,
                        Data.Acid.TemplateHaskell
+                       Data.Acid.Repair
 
   Other-modules:       Paths_acid_state,
                        FileIO
@@ -72,6 +73,15 @@ Library
 
   default-language:    Haskell2010
   GHC-Options:         -fwarn-unused-imports -fwarn-unused-binds
+
+executable acid-state-repair
+  hs-source-dirs: repair
+  build-depends: acid-state
+               , base
+               , directory
+  main-is: Main.hs
+  default-language:    Haskell2010
+
 
 test-suite specs
   type:                exitcode-stdio-1.0

--- a/repair/Main.hs
+++ b/repair/Main.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Acid.Repair
+import System.Directory
+
+main :: IO ()
+main = do
+    directory <- getCurrentDirectory
+    repairEvents directory
+    repairCheckpoints directory

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -27,6 +27,8 @@ module Data.Acid.Local
     , Checkpoint(..)
     , SerialisationLayer(..)
     , defaultSerialisationLayer
+    , mkEventsLogKey
+    , mkCheckpointsLogKey
     ) where
 
 import Data.Acid.Archive
@@ -350,6 +352,20 @@ data SerialisationLayer st =
 defaultSerialisationLayer :: SafeCopy st => SerialisationLayer st
 defaultSerialisationLayer = SerialisationLayer safeCopySerialiser safeCopySerialiser defaultArchiver
 
+mkEventsLogKey :: FilePath -> SerialisationLayer object -> LogKey (Tagged ByteString)
+mkEventsLogKey directory serialisationLayer =
+  LogKey { logDirectory = directory
+         , logPrefix = "events"
+         , logSerialiser = eventSerialiser serialisationLayer
+         , logArchiver   = archiver serialisationLayer }
+
+mkCheckpointsLogKey :: FilePath -> SerialisationLayer object -> LogKey (Checkpoint object)
+mkCheckpointsLogKey directory serialisationLayer =
+  LogKey { logDirectory = directory
+         , logPrefix = "checkpoints"
+         , logSerialiser = checkpointSerialiser serialisationLayer
+         , logArchiver = archiver serialisationLayer }
+
 resumeLocalStateFrom :: (IsAcidic st)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
@@ -371,14 +387,8 @@ resumeLocalStateFrom directory initialState delayLocking serialisationLayer =
         replayEvents lock n st
   where
     lockFile = directory </> "open.lock"
-    eventsLogKey = LogKey { logDirectory = directory
-                          , logPrefix = "events"
-                          , logSerialiser = eventSerialiser serialisationLayer
-                          , logArchiver   = archiver serialisationLayer }
-    checkpointsLogKey = LogKey { logDirectory = directory
-                               , logPrefix = "checkpoints"
-                               , logSerialiser = checkpointSerialiser serialisationLayer
-                               , logArchiver = archiver serialisationLayer }
+    eventsLogKey = mkEventsLogKey directory serialisationLayer
+    checkpointsLogKey = mkCheckpointsLogKey directory serialisationLayer
     loadCheckpoint = do
       mbLastCheckpoint <- Log.newestEntry checkpointsLogKey
       case mbLastCheckpoint of

--- a/src/Data/Acid/Log.hs
+++ b/src/Data/Acid/Log.hs
@@ -18,6 +18,7 @@ module Data.Acid.Log
     , askCurrentEntryId
     , cutFileLog
     , archiveFileLog
+    , findLogFiles
     ) where
 
 import Data.Acid.Archive (Archiver(..), Entries(..), entriesToList)

--- a/src/Data/Acid/Repair.hs
+++ b/src/Data/Acid/Repair.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Data.Acid.Repair
+  ( repairFile
+  , repairEvents
+  , repairCheckpoints
+  ) where
+
+import qualified Data.Acid.Archive as Archive
+import Data.Acid.Local (mkEventsLogKey, mkCheckpointsLogKey)
+import Data.Acid.Log (LogKey)
+import qualified Data.Acid.Log as Log
+import qualified Data.ByteString.Lazy as Lazy
+import Data.List
+import System.Directory
+import System.FilePath.Posix
+import System.IO (hClose, openTempFile)
+
+repairEntries :: Lazy.ByteString -> Lazy.ByteString
+repairEntries =
+  Archive.packEntries . Archive.entriesToListNoFail . Archive.readEntries
+
+-- | @'repairFile' path@ will truncate the entries in @file@ until there are
+-- only valid entries (if a corrupted entry is found, then the rest of the file
+-- is truncated).
+--
+-- The old file will be copied to @path.bak@ (or @path.bak.1@, etc… if the file
+-- already exists).
+--
+-- 'repairFile' tries very hard to avoid leaving files in an inconsistent state:
+-- the truncated file is written in a temporary file, which is then moved into
+-- place, similarly copies are performed with moves instead. Still this is not
+-- fully atomic: there are two consecutive moves, so 'repairFile' may, in case
+-- of crash, yield a state where the @path.bak@ file is there but no @path@ is
+-- there anymore, this would require manual intervention.
+repairFile :: FilePath -> IO ()
+repairFile fp = do
+    broken <- Lazy.readFile fp
+    let repaired = repairEntries broken
+    (tmp, temph) <- openTempFile (takeDirectory fp) (takeFileName fp)
+      -- We use `openTempFile`, here, rather than `findNext` because we want to
+      -- make extra-sure that we are not overriding an important file.
+    hClose temph
+      -- Closing immediately to benefit from the bracket guarantees of
+      -- `writeFile`. A more elegant solution would be to use a `withTempFile`
+      -- function, such as that from package `temporary`.
+    Lazy.writeFile tmp repaired
+    dropFile fp
+    renameFile tmp fp
+
+-- Repairs the files corresponding to the given 'LogKey'. It implements the
+-- logic described in 'repairEvents'.
+repairLogs :: LogKey object -> IO ()
+repairLogs identifier = do
+    logFiles <- Log.findLogFiles identifier
+    let sorted = sort logFiles
+        (_eventIds, files) = unzip sorted
+    broken_files <- mapM needsRepair files
+      -- We're doing a second deserialisation of the files here (see
+      -- 'needsRepair'). It would be better, computation-time-wise to make as
+      -- single pass and let `repairEntries`, for instance, return whether a fix
+      -- is needed. But it's a lot of complication and requires loading the
+      -- entire base in memory, rather than streaming files one-by-one. So it's
+      -- better to just do the second pass.
+    repair $ map snd $ dropWhile (\(b,_) -> not b) $ zip broken_files files
+  where
+    repair [] = return ()
+    repair (file:rest) = do
+      mapM_ dropFile (reverse rest)
+      repairFile file
+
+-- Moves (atomically) a file `path` to `path.bak` (or `path.bak.1`, etc… if the
+-- file already exists).
+dropFile :: FilePath -> IO ()
+dropFile fp = do
+    bak <- findNext (fp ++ ".bak")
+      -- We're using `findNext` rather than `openTempFile`, here, because we
+      -- want predictable names
+    renameFile fp bak
+
+-- | Repairs the WAL files with the following strategy:
+--
+-- * Let `f` be the oldest corrupted file.
+-- * All files older than `f` is left untouched
+-- * `f` is repaired with `repairFile`
+-- * Old files younger than `f` is dropped (and saved to `path.bak`, or
+--   `path.bak.1`, etc…)
+--
+-- In other words, all the log entries after the first corrupted entry is
+-- dropped. The reasoning is that newer entries are likely not to make sense
+-- after some entries have been removed from the log. This strategy guarantees a
+-- consistent state, albeit a potentially old one.
+repairEvents
+  :: FilePath -- ^ Directory in which the events files can be found.
+  -> IO ()
+repairEvents directory =
+    repairLogs (mkEventsLogKey directory noserialisation)
+  where
+    noserialisation =
+      error "Repair.repairEvents: the serialisation layer shouldn't be forced"
+
+-- | Repairs the checkpoints file using the following strategy:
+--
+-- * Every checkpoints file is repaired with `repairFile`
+--
+-- Checkpoints are mostly independent. Contrary to 'repairEvents', dropping a
+-- checkpoint doesn't affect the consistency of later checkpoints.
+repairCheckpoints
+  :: FilePath -- ^ Directory in which the checkpoints files can be found.
+  -> IO ()
+repairCheckpoints directory = do
+    let checkpointLogKey = mkCheckpointsLogKey directory noserialisation
+    checkpointFiles <- Log.findLogFiles checkpointLogKey
+    let (_eventIds, files) = unzip checkpointFiles
+    mapM_ repairFile files
+  where
+    noserialisation =
+      error "Repair.repairCheckpoints: the serialisation layer shouldn't be forced"
+
+needsRepair :: FilePath -> IO Bool
+needsRepair fp = do
+    contents <- Lazy.readFile fp
+    let entries = Archive.readEntries contents
+    return $ entriesNeedRepair entries
+  where
+    entriesNeedRepair Archive.Fail{} = True
+    entriesNeedRepair Archive.Done = False
+    entriesNeedRepair (Archive.Next _ rest) = entriesNeedRepair rest
+
+findNext :: FilePath -> IO (FilePath)
+findNext fp = go 0
+  where
+    go n =
+      let next = fileWithSuffix fp n in
+      doesFileExist next >>= \case
+        False -> return next
+        True -> go (n+1)
+
+fileWithSuffix :: FilePath -> Int -> FilePath
+fileWithSuffix fp i =
+  if i == 0 then fp
+  else fp ++ "." ++ show i


### PR DESCRIPTION
Quickstart:

From an acid-state database directory:
```
$ acid-state-repair
```

(also available as a library in `Data.Acid.Repair`)

This will:

- Truncate all events after the first corrupted event in the WAL
- Remove all checkpoints which are corrupted (and possibly more if the corrupted checkpoint is not the last in its file)

The database is restored to a healthy, consistent, state. And can be loaded again. All the modified files are saved as `foo.bak` (or `foo.bak.1`, etc… if files already exist).

Currently a tad overeager with checkpoints: they are all copied to a `.bak` file, even if they were healthy. A future optimisation could avoid this.

This addresses, at least in part, #79 (I'll leave the interested parties to decide whether this is a sufficient to warrant closing the issue), by letting the database administrator to deal with failures, rather than trying to make an automated decision (which the thread in #79 outlines is rather difficult).