### PR TITLE
Support latest GHC and network

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -55,7 +55,8 @@ Library
                        filelock,
                        filepath,
                        mtl,
-                       network < 3.2,
+                       network >= 3.1 && <3.2,
+                       network-bsd,
                        template-haskell,
                        th-expand-syns
 

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -55,7 +55,7 @@ Library
                        filelock,
                        filepath,
                        mtl,
-                       network < 2.9,
+                       network < 3.2,
                        template-haskell,
                        th-expand-syns
 

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -57,7 +57,7 @@ Library
                        mtl,
                        network >= 3.1 && <3.2,
                        network-bsd,
-                       template-haskell,
+                       template-haskell < 2.16,
                        th-expand-syns
 
   if os(windows)

--- a/examples/KeyValue.hs
+++ b/examples/KeyValue.hs
@@ -11,7 +11,6 @@ import           Control.Applicative
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.SafeCopy
-import           Network
 import           System.Environment
 import           System.Exit
 import           System.IO

--- a/examples/Proxy.hs
+++ b/examples/Proxy.hs
@@ -11,7 +11,6 @@ import           Data.Acid.Remote
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.SafeCopy
-import           Network
 import           System.Environment
 import           System.IO
 
@@ -45,17 +44,19 @@ openLocal :: IO (AcidState ProxyStressState)
 openLocal = openLocalState (StressState 0)
 
 openRemote :: String -> IO (AcidState ProxyStressState)
-openRemote socket = openRemoteState skipAuthenticationPerform "localhost" (UnixSocket socket)
+openRemote socket = openRemoteState skipAuthenticationPerform "localhost" port
+
+port = 6303
 
 main :: IO ()
 main = do args <- getArgs
           case args of
             ["server", socket]
               -> do acid <- openLocal
-                    acidServer skipAuthenticationCheck (UnixSocket socket) acid
+                    acidServer skipAuthenticationCheck port acid
             ["proxy", from, to]
               -> do acid <- openRemote from
-                    acidServer skipAuthenticationCheck (UnixSocket to) acid
+                    acidServer skipAuthenticationCheck port acid
             ["query", socket]
               -> do acid <- openRemote socket
                     n <- query acid QueryState

--- a/examples/RemoteClient.hs
+++ b/examples/RemoteClient.hs
@@ -4,7 +4,6 @@ import           Control.Monad.Reader
 import           Data.Acid
 import           Data.Acid.Advanced
 import           Data.Acid.Remote
-import           Network
 import           RemoteCommon
 import           System.Environment
 import           System.IO
@@ -13,7 +12,7 @@ import           System.IO
 -- This is how AcidState is used:
 
 open :: IO (AcidState StressState)
-open = openRemoteState skipAuthenticationPerform "localhost" (PortNumber 8080)
+open = openRemoteState skipAuthenticationPerform "localhost" 8080
 
 main :: IO ()
 main = do args <- getArgs

--- a/examples/RemoteServer.hs
+++ b/examples/RemoteServer.hs
@@ -3,9 +3,8 @@ module RemoteServer where
 import           Control.Exception (bracket)
 import           Data.Acid         (closeAcidState, openLocalState)
 import           Data.Acid.Remote  (acidServer, skipAuthenticationCheck)
-import           Network           (PortID (..))
 import           RemoteCommon      (StressState (..))
 
 main :: IO ()
 main = bracket (openLocalState $ StressState 0)
-       closeAcidState $ acidServer skipAuthenticationCheck (PortNumber 8080)
+       closeAcidState $ acidServer skipAuthenticationCheck 8080

--- a/examples/errors/Exceptions.hs
+++ b/examples/errors/Exceptions.hs
@@ -29,7 +29,7 @@ $(deriveSafeCopy 0 'base ''MyState)
 -- The transaction we will execute over the state.
 
 failEvent :: Update MyState ()
-failEvent = fail "fail!"
+failEvent = pure $ error "fail!"
 
 errorEvent :: Update MyState ()
 errorEvent = error "error!"

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -373,7 +373,10 @@ makeMethodInstance eventName eventType = do
     instanceD
         instanceContext
         (return ty)
-#if __GLASGOW_HASKELL__ >= 707
+#if MIN_VERSION_template_haskell(2,15,0)
+        [ tySynInstD $ tySynEqn Nothing (conT ''MethodResult `appT` structType) (return resultType)
+        , tySynInstD $ tySynEqn Nothing (conT ''MethodState `appT` structType) (return stateType)
+#elif __GLASGOW_HASKELL__ >= 707
         [ tySynInstD ''MethodResult (tySynEqn [structType] (return resultType))
         , tySynInstD ''MethodState  (tySynEqn [structType] (return stateType))
 #else


### PR DESCRIPTION
Makes it buildable on the current ecosystem with GHC 8.8.

If we want to continue the support for Unix sockets, we may need to introduce a breaking change to the API.