### PR TITLE
Compatibility with Template Haskell 2.17 and 2.18 (GHC 9.0 and 9.2)

### DIFF
--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -57,7 +57,7 @@ Library
                        mtl,
                        network < 3.2,
                        network-bsd,
-                       template-haskell < 2.17,
+                       template-haskell < 2.19,
                        th-expand-syns
 
   if os(windows)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ clone_folder: "c:\\WORK"
 
 environment:
   global:
-    CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http"
+    CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http --constraint='barbies<1'"
   matrix:
     # - GHCVER: "8.6.3"
     #   CHOCOPTS:

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -20,6 +20,10 @@ import Control.Monad
 import Control.Monad.State (MonadState)
 import Control.Monad.Reader (MonadReader)
 
+#if !MIN_VERSION_template_haskell(2,17,0)
+type TyVarBndrUnit = TyVarBndr
+#endif
+
 {-| Create the control structures required for acid states
     using Template Haskell.
 
@@ -97,7 +101,7 @@ makeAcidicWithSerialiser ss stateName eventNames
                  _ -> error "Data.Acid.TemplateHaskell: Unsupported state type. Only 'data', 'newtype' and 'type' are supported."
            _ -> error "Data.Acid.TemplateHaskell: Given state is not a type."
 
-makeAcidic' :: SerialiserSpec -> [Name] -> Name -> [TyVarBndr] -> [Con] -> Q [Dec]
+makeAcidic' :: SerialiserSpec -> [Name] -> Name -> [TyVarBndrUnit] -> [Con] -> Q [Dec]
 makeAcidic' ss eventNames stateName tyvars constructors
     = do events <- sequence [ makeEvent ss eventName | eventName <- eventNames ]
          acidic <- makeIsAcidic ss eventNames stateName tyvars constructors
@@ -197,11 +201,11 @@ makeIsAcidic ss eventNames stateName tyvars constructors
 --
 -- In this case we have to rename 'x' to the actual state we're going to
 -- use. This is done by 'renameState'.
-eventCxts :: Type        -- ^ State type
-          -> [TyVarBndr] -- ^ type variables that will be used for the State type in the IsAcidic instance
-          -> Name        -- ^ 'Name' of the event
-          -> Type        -- ^ 'Type' of the event
-          -> [Pred]      -- ^ extra context to add to 'IsAcidic' instance
+eventCxts :: Type            -- ^ State type
+          -> [TyVarBndrUnit] -- ^ type variables that will be used for the State type in the IsAcidic instance
+          -> Name            -- ^ 'Name' of the event
+          -> Type            -- ^ 'Type' of the event
+          -> [Pred]          -- ^ extra context to add to 'IsAcidic' instance
 eventCxts targetStateType targetTyVars eventName eventType =
     let TypeAnalysis { context = cxt, stateType }
                     = analyseType eventName eventType
@@ -227,8 +231,15 @@ eventCxts targetStateType targetTyVars eventName eventType =
       rename pred table t@(ForallT tyvarbndrs cxt typ) = -- this is probably wrong? I don't think acid-state can really handle this type anyway..
           ForallT (map renameTyVar tyvarbndrs) (map (unify table) cxt) (rename pred table typ)
           where
+#if MIN_VERSION_template_haskell(2,17,0)
+            renameTyVar :: TyVarBndr a -> TyVarBndr a
+            renameTyVar (PlainTV name ann)    = PlainTV  (renameName pred table name) ann
+            renameTyVar (KindedTV name k ann) = KindedTV (renameName pred table name) k ann
+#else
+            renameTyVar :: TyVarBndr -> TyVarBndr
             renameTyVar (PlainTV name)    = PlainTV  (renameName pred table name)
             renameTyVar (KindedTV name k) = KindedTV (renameName pred table name) k
+#endif
       rename pred table (VarT n)   = VarT $ renameName pred table n
       rename pred table (AppT a b) = AppT (rename pred table a) (rename pred table b)
       rename pred table (SigT a k) = SigT (rename pred table a) k
@@ -400,7 +411,7 @@ makeEventInstance eventName eventType
           eventStructName = toStructName eventName
 
 data TypeAnalysis = TypeAnalysis
-    { tyvars :: [TyVarBndr]
+    { tyvars :: [TyVarBndrUnit]
     , context :: Cxt
     , argumentTypes :: [Type]
     , stateType :: Type
@@ -455,7 +466,11 @@ analyseType eventName t = go [] [] [] t
                 }
     -- (...) => a
     go tyvars cxt args (ForallT tyvars2 cxt2 a)
-        = go (tyvars ++ tyvars2) (cxt ++ cxt2) args a
+#if MIN_VERSION_template_haskell(2,17,0)
+        = go (tyvars ++ fmap void tyvars2) (cxt ++ cxt2) args a
+#else
+        = go (tyvars ++ tyvars2)           (cxt ++ cxt2) args a
+#endif
     -- (MonadState state m) => ... -> m result
     -- (MonadReader state m) => ... -> m result
     go tyvars' cxt argumentTypes (AppT (VarT m) resultType)
@@ -489,12 +504,21 @@ findTyVars (SigT a _) = findTyVars a
 findTyVars _          = []
 
 -- | extract the 'Name' from a 'TyVarBndr'
+#if MIN_VERSION_template_haskell(2,17,0)
+tyVarBndrName :: TyVarBndr a -> Name
+tyVarBndrName (PlainTV n _)    = n
+tyVarBndrName (KindedTV n _ _) = n
+
+allTyVarBndrNames :: [TyVarBndr a] -> [Name]
+allTyVarBndrNames tyvars = map tyVarBndrName tyvars
+#else
 tyVarBndrName :: TyVarBndr -> Name
 tyVarBndrName (PlainTV n)    = n
 tyVarBndrName (KindedTV n _) = n
 
 allTyVarBndrNames :: [TyVarBndr] -> [Name]
 allTyVarBndrNames tyvars = map tyVarBndrName tyvars
+#endif
 
 -- | Convert the 'Name' of the event function into the name of the
 -- corresponding data constructor.

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -144,7 +144,12 @@ spec = do
         let x = mkName "x"
 
         it "accepts constrained type variables in the state" $ do
-            let binders = [PlainTV (mkName "x")]
+            let binders :: [TyVarBndrUnit]
+#if MIN_VERSION_template_haskell(2,17,0)
+                binders = [PlainTV (mkName "x") ()]
+#else
+                binders = [PlainTV (mkName "x")]
+#endif
                 stateType = ConT ''Maybe `AppT` VarT x
             eventType <- runQ [t| forall a. (Ord a) => Int -> Query (Maybe a) Int|]
 


### PR DESCRIPTION
Tested with

    cabal test -w ghc-8.4.4 --enable-tests --constraint='barbies<1' -f -skip-state-machine-test
    cabal test -w ghc-9.0.2 --enable-tests --constraint='barbies<1' -f -skip-state-machine-test
    cabal test -w ghc-9.2.1 --enable-tests -f +skip-state-machine-test

All these test run passed.

The state-machine test needs Barbies, but Barbies 0.x doesn't work with
ghc-9.2.1. So I skip that test for 9.2.1, as you can see above. This is an
upstream issue since we are not depending on Barbies directly. I think it is
probably a violation of PVP rules.

Other tests still work and pass on GHC 9.2.1 and there is little reason to
believe anything would break for 9.2.1.
