### PR TITLE
Support newer hedgehog

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -202,7 +202,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package acid-state" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          constraints: barbies < 1
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(acid-state)$/; }' >> cabal.project.local
           cat cabal.project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ clone_folder: "c:\\WORK"
 
 environment:
   global:
-    CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http --constraint='barbies<1'"
+    CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http"
   matrix:
     # - GHCVER: "8.6.3"
     #   CHOCOPTS:

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,0 @@
-packages: .
-
--- package hedgehog
-constraints: barbies < 1
-
--- -- This is not picked up by haskell-ci
--- package acid-state
---   flags: +skip-state-machine-test


### PR DESCRIPTION
This drops the `barbies < 1` constraint (which had the effect of requiring `hedgehog < 1.1`). This allows the state-machine test to build on GHC 9.2.