### PR TITLE
Make createCheckpointAndClose part of public interface

### DIFF
--- a/src/Data/Acid.hs
+++ b/src/Data/Acid.hs
@@ -19,6 +19,7 @@ module Data.Acid
     , openLocalStateFrom
     , closeAcidState
     , createCheckpoint
+    , createCheckpointAndClose
     , createArchive
     , update
     , query

--- a/src/Data/Acid/Abstract.hs
+++ b/src/Data/Acid/Abstract.hs
@@ -7,8 +7,6 @@ module Data.Acid.Abstract
     , update'
     , query
     , query'
-    , mkAnyState
-    , downcast
     ) where
 
 import Data.Acid.Common
@@ -18,18 +16,6 @@ import Control.Concurrent      ( MVar, takeMVar )
 import Data.ByteString.Lazy    ( ByteString )
 import Control.Monad           ( void )
 import Control.Monad.Trans     ( MonadIO(liftIO) )
-#if __GLASGOW_HASKELL__ >= 707
-import Data.Typeable           ( Typeable, gcast, typeOf )
-#else
-import Data.Typeable           ( Typeable1, gcast1, typeOf1 )
-#endif
-
-data AnyState st where
-#if __GLASGOW_HASKELL__ >= 707
-  AnyState :: Typeable sub_st => sub_st st -> AnyState st
-#else
-  AnyState :: Typeable1 sub_st => sub_st st -> AnyState st
-#endif
 
 -- Haddock doesn't get the types right on its own.
 {-| State container offering full ACID (Atomicity, Consistency, Isolation and Durability)
@@ -79,7 +65,6 @@ data AcidState st
 -- | Close an AcidState and associated resources.
 --   Any subsequent usage of the AcidState will throw an exception.
                 closeAcidState :: IO ()
-              , acidSubState :: AnyState st
               }
 
 -- | Issue an Update event and return immediately. The event is not durable
@@ -125,32 +110,3 @@ query acid = _query acid -- Redirection to make Haddock happy.
 -- | Same as 'query' but lifted into any monad capable of doing IO.
 query' :: (QueryEvent event, MonadIO m) => AcidState (EventState event) -> event -> m (EventResult event)
 query' acidState event = liftIO (query acidState event)
-
-#if __GLASGOW_HASKELL__ >= 707
-mkAnyState :: Typeable sub_st => sub_st st -> AnyState st
-#else
-mkAnyState :: Typeable1 sub_st => sub_st st -> AnyState st
-#endif
-mkAnyState = AnyState
-
-#if __GLASGOW_HASKELL__ >= 707
-downcast :: (Typeable sub, Typeable st) => AcidState st -> sub st
-downcast AcidState{acidSubState = AnyState sub}
-  = r
- where
-   r = case gcast (Just sub) of
-         Just (Just x) -> x
-         _ ->
-           error $
-            "Data.Acid.Abstract: Invalid subtype cast: " ++ show (typeOf sub) ++ " -> " ++ show (typeOf r)
-#else
-downcast :: Typeable1 sub => AcidState st -> sub st
-downcast AcidState{acidSubState = AnyState sub}
-  = r
- where
-   r = case gcast1 (Just sub) of
-         Just (Just x) -> x
-         _ ->
-           error $
-            "Data.Acid.Abstract: Invalid subtype cast: " ++ show (typeOf1 sub) ++ " -> " ++ show (typeOf1 r)
-#endif

--- a/src/Data/Acid/Abstract.hs
+++ b/src/Data/Acid/Abstract.hs
@@ -58,6 +58,16 @@ data AcidState st
 --
 --   This call will not return until the operation has succeeded.
                 createCheckpoint :: IO ()
+              ,
+-- | Save a snapshot to disk and close the AcidState as a single
+--   atomic action, if supported by the backend. This is useful when
+--   you want to make sure that no events are saved to disk after a
+--   checkpoint.
+--
+--   This is supported for the Local backend.  For the Remote and
+--   Memory backends, this is equivalent to calling 'createCheckpoint'
+--   followed by 'closeAcidState', without atomicity guarantees.
+                createCheckpointAndClose :: IO ()
 -- | Move all log files that are no longer necessary for state restoration into the 'Archive'
 --   folder in the state directory. This folder can then be backed up or thrown out as you see fit.
 --   Reverting to a state before the last checkpoint will not be possible if the 'Archive' folder

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -464,5 +464,4 @@ toAcidState local
               , createCheckpointAndClose = createLocalCheckpointAndClose local
               , createArchive = createLocalArchive local
               , closeAcidState = closeLocalState local
-              , acidSubState = mkAnyState local
               }

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -200,8 +200,8 @@ createLocalCheckpoint acidState
 -- | Save a snapshot to disk and close the AcidState as a single atomic
 --   action. This is useful when you want to make sure that no events
 --   are saved to disk after a checkpoint.
-createCheckpointAndClose :: (IsAcidic st, Typeable st) => AcidState st -> IO ()
-createCheckpointAndClose abstract_state
+createLocalCheckpointAndClose :: IsAcidic st => LocalState st -> IO ()
+createLocalCheckpointAndClose acidState
     = do mvar <- newEmptyMVar
          closeCore' (localCore acidState) $ \st ->
            do eventId <- askCurrentEntryId (localEvents acidState)
@@ -211,7 +211,6 @@ createCheckpointAndClose abstract_state
          closeFileLog (localEvents acidState)
          closeFileLog (localCheckpoints acidState)
          unlockFile (localLock acidState)
-  where acidState = downcast abstract_state
 
 
 data Checkpoint s = Checkpoint EntryId s
@@ -462,6 +461,7 @@ toAcidState local
               , _query = localQuery local
               , queryCold = localQueryCold local
               , createCheckpoint = createLocalCheckpoint local
+              , createCheckpointAndClose = createLocalCheckpointAndClose local
               , createArchive = createLocalArchive local
               , closeAcidState = closeLocalState local
               , acidSubState = mkAnyState local

--- a/src/Data/Acid/Memory.hs
+++ b/src/Data/Acid/Memory.hs
@@ -123,6 +123,7 @@ toAcidState memory
               , _query             = memoryQuery memory
               , queryCold          = memoryQueryCold memory
               , createCheckpoint   = createMemoryCheckpoint memory
+              , createCheckpointAndClose = createMemoryCheckpoint memory >> closeMemoryState memory
               , createArchive      = createMemoryArchive memory
               , closeAcidState     = closeMemoryState memory
               , acidSubState       = mkAnyState memory

--- a/src/Data/Acid/Memory.hs
+++ b/src/Data/Acid/Memory.hs
@@ -126,5 +126,4 @@ toAcidState memory
               , createCheckpointAndClose = createMemoryCheckpoint memory >> closeMemoryState memory
               , createArchive      = createMemoryArchive memory
               , closeAcidState     = closeMemoryState memory
-              , acidSubState       = mkAnyState memory
               }

--- a/src/Data/Acid/Remote.hs
+++ b/src/Data/Acid/Remote.hs
@@ -610,7 +610,6 @@ toAcidState remote
               , createCheckpointAndClose = createRemoteCheckpoint remote >> closeRemoteState remote
               , createArchive      = createRemoteArchive remote
               , closeAcidState     = closeRemoteState remote
-              , acidSubState       = mkAnyState remote
               }
   where
     mmap :: MethodMap st

--- a/src/Data/Acid/Remote.hs
+++ b/src/Data/Acid/Remote.hs
@@ -607,6 +607,7 @@ toAcidState remote
               , _query             = remoteQuery remote mmap
               , queryCold          = remoteQueryCold remote
               , createCheckpoint   = createRemoteCheckpoint remote
+              , createCheckpointAndClose = createRemoteCheckpoint remote >> closeRemoteState remote
               , createArchive      = createRemoteArchive remote
               , closeAcidState     = closeRemoteState remote
               , acidSubState       = mkAnyState remote

--- a/test/Data/Acid/StateMachineTest.hs
+++ b/test/Data/Acid/StateMachineTest.hs
@@ -46,7 +46,6 @@ import           Control.Monad.State
 import qualified Data.Acid as Acid
 import qualified Data.Acid.Common as Common
 import qualified Data.Acid.Core as Core
-import qualified Data.Acid.Local as Local
 import           Data.Maybe
 import qualified Data.SafeCopy as SafeCopy
 import           Data.Typeable
@@ -168,7 +167,7 @@ acidStateInterface fp =
     AcidStateInterface { openState            = Acid.openLocalStateFrom fp
                        , closeState           = Acid.closeAcidState
                        , checkpointState      = Acid.createCheckpoint
-                       , checkpointCloseState = Local.createCheckpointAndClose
+                       , checkpointCloseState = Acid.createCheckpointAndClose
                        , resetState           = removeDirectoryRecursive fp
                                                   `catch` (\ (_ :: IOException) -> return ())
                        , statePath            = fp


### PR DESCRIPTION
Fixes #112. This exposes `createCheckpointAndClose` via `Data.Acid[.Abstract]` and makes it work for all backends:
 - On the Local backend it works as it always did, creating a checkpoint and not writing any events afterwards.
 - On the Memory/Remote backends it simply calls the create checkpoint operation followed by the close operation. (Previously calling `createCheckpointAndClose` on these backends would throw an error as the downcast failed.)

I've also removed the dynamically-typed stuff in a separate commit, since it is not used for anything else in `acid-state`. It is conceivable that it might be used by dependent packages, though, so we could imagine keeping this in. I'm not convinced it provides a good interface though.

This needs a changelog update, assuming there is consensus that this is a sensible change. 