### PR TITLE
Add HasCallStack constraints to the open and close functions

### DIFF
--- a/src/Data/Acid/Core.hs
+++ b/src/Data/Acid/Core.hs
@@ -69,6 +69,8 @@ import Data.Typeable                      ( tyConModule )
 import Data.Typeable.Internal             ( tyConModule )
 #endif
 
+import GHC.Stack                          ( HasCallStack )
+
 #if MIN_VERSION_base(4,4,0)
 
 -- in base >= 4.4 the Show instance for TypeRep no longer provides a
@@ -170,13 +172,13 @@ mkCore methods initialValue
                     , coreMethods = mkMethodMap methods }
 
 -- | Mark Core as closed. Any subsequent use will throw an exception.
-closeCore :: Core st -> IO ()
+closeCore :: HasCallStack => Core st -> IO ()
 closeCore core
     = closeCore' core (\_st -> return ())
 
 -- | Access the state and then mark the Core as closed. Any subsequent use
 --   will throw an exception.
-closeCore' :: Core st -> (st -> IO ()) -> IO ()
+closeCore' :: HasCallStack => Core st -> (st -> IO ()) -> IO ()
 closeCore' core action
     = modifyMVar_ (coreState core) $ \st ->
       do action st
@@ -185,7 +187,7 @@ closeCore' core action
 
 -- | Modify the state component. The resulting state is ensured to be in
 --   WHNF.
-modifyCoreState :: Core st -> (st -> IO (st, a)) -> IO a
+modifyCoreState :: HasCallStack => Core st -> (st -> IO (st, a)) -> IO a
 modifyCoreState core action
     = modifyMVar (coreState core) $ \st -> do (!st', a) <- action st
                                               return (st', a)

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -52,6 +52,7 @@ import Data.SafeCopy                  ( SafeCopy(..), safeGet, safePut
                                       , primitive, contain )
 import Data.Typeable                  ( Typeable, typeOf )
 import Data.IORef
+import GHC.Stack                      ( HasCallStack )
 import System.FilePath                ( (</>), takeDirectory )
 import System.FileLock
 import System.Directory               ( createDirectoryIfMissing )
@@ -189,7 +190,7 @@ localQueryCold acidState event
 --   with this call.
 --
 --   This call will not return until the operation has succeeded.
-createLocalCheckpoint :: IsAcidic st => LocalState st -> IO ()
+createLocalCheckpoint :: HasCallStack => IsAcidic st => LocalState st -> IO ()
 createLocalCheckpoint acidState
     = do cutFileLog (localEvents acidState)
          mvar <- newEmptyMVar
@@ -202,7 +203,7 @@ createLocalCheckpoint acidState
 -- | Save a snapshot to disk and close the AcidState as a single atomic
 --   action. This is useful when you want to make sure that no events
 --   are saved to disk after a checkpoint.
-createCheckpointAndClose :: (IsAcidic st, Typeable st) => AcidState st -> IO ()
+createCheckpointAndClose :: (IsAcidic st, Typeable st, HasCallStack) => AcidState st -> IO ()
 createCheckpointAndClose abstract_state
     = do mvar <- newEmptyMVar
          closeCore' (localCore acidState) $ \st ->
@@ -250,7 +251,7 @@ instance SafeCopy s => SafeCopy (Checkpoint s) where
 -- | Create an AcidState given an initial value.
 --
 --   This will create or resume a log found in the \"state\/[typeOf state]\/\" directory.
-openLocalState :: (Typeable st, IsAcidic st, SafeCopy st)
+openLocalState :: (Typeable st, IsAcidic st, SafeCopy st, HasCallStack)
               => st                          -- ^ Initial state value. This value is only used if no checkpoint is
                                              --   found.
               -> IO (AcidState st)
@@ -279,7 +280,7 @@ defaultStateDirectory initialState = "state" </> show (typeOf initialState)
 --   This will create or resume a log found in @directory@.
 --   Running two AcidState's from the same directory is an error
 --   but will not result in dataloss.
-openLocalStateFrom :: (IsAcidic st, SafeCopy st)
+openLocalStateFrom :: (IsAcidic st, SafeCopy st, HasCallStack)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
                                          --   found.
@@ -292,7 +293,7 @@ openLocalStateFrom directory initialState =
 --   This will create or resume a log found in @directory@.
 --   Running two AcidState's from the same directory is an error
 --   but will not result in dataloss.
-openLocalStateWithSerialiser :: (IsAcidic st)
+openLocalStateWithSerialiser :: (IsAcidic st, HasCallStack)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
                                          --   found.
@@ -306,7 +307,7 @@ openLocalStateWithSerialiser directory initialState serialisationLayer =
 --   This will create or resume a log found in @directory@.
 --   The most recent checkpoint will be loaded immediately but the AcidState will not be opened
 --   until the returned function is executed.
-prepareLocalStateFrom :: (IsAcidic st, SafeCopy st)
+prepareLocalStateFrom :: (IsAcidic st, SafeCopy st, HasCallStack)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
                                          --   found.
@@ -319,7 +320,7 @@ prepareLocalStateFrom directory initialState =
 --   This will create or resume a log found in @directory@.
 --   The most recent checkpoint will be loaded immediately but the AcidState will not be opened
 --   until the returned function is executed.
-prepareLocalStateWithSerialiser :: (IsAcidic st)
+prepareLocalStateWithSerialiser :: (IsAcidic st, HasCallStack)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
                                          --   found.
@@ -369,7 +370,7 @@ mkCheckpointsLogKey directory serialisationLayer =
          , logSerialiser = checkpointSerialiser serialisationLayer
          , logArchiver = archiver serialisationLayer }
 
-resumeLocalStateFrom :: (IsAcidic st)
+resumeLocalStateFrom :: (IsAcidic st, HasCallStack)
                   => FilePath            -- ^ Location of the checkpoint and transaction files.
                   -> st                  -- ^ Initial state value. This value is only used if no checkpoint is
                                          --   found.
@@ -430,14 +431,14 @@ checkpointRestoreError msg
 
 -- | Close an AcidState and associated logs.
 --   Any subsequent usage of the AcidState will throw an exception.
-closeLocalState :: LocalState st -> IO ()
+closeLocalState :: HasCallStack => LocalState st -> IO ()
 closeLocalState acidState
     = do closeCore (localCore acidState)
          closeFileLog (localEvents acidState)
          closeFileLog (localCheckpoints acidState)
          unlockFile (localLock acidState)
 
-createLocalArchive :: LocalState st -> IO ()
+createLocalArchive :: HasCallStack => LocalState st -> IO ()
 createLocalArchive state
   = do -- We need to look at the last checkpoint saved to disk. Since checkpoints can be written
        -- in parallel with this call, we can't guarantee that the checkpoint we get really is the


### PR DESCRIPTION
...so that error calls return a stack trace.