### PR TITLE
Add Typeable constraint to IsAcidic

### DIFF
--- a/examples/ParameterisedState.hs
+++ b/examples/ParameterisedState.hs
@@ -37,7 +37,7 @@ instance (Ord k, Serialize k, SafeCopy k, Typeable k) => SafeCopy (Store k)
 instance (Ord k, Serialize k) => Serialize (Store k)
 
 insertStore
-    :: (Ord k, Serialize k)
+    :: (Ord k, Serialize k, Typeable k)
     => Entry k
     -> Update (Store k) k
 insertStore item = do

--- a/src/Data/Acid/Common.hs
+++ b/src/Data/Acid/Common.hs
@@ -20,9 +20,10 @@ import Control.Monad.Reader  (MonadReader, Reader, runReader)
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
 #endif
+import Data.Typeable (Typeable)
 
 
-class IsAcidic st where
+class Typeable st => IsAcidic st where
     acidEvents :: [Event st]
       -- ^ List of events capable of updating or querying the state.
 

--- a/src/Data/Acid/Core.hs
+++ b/src/Data/Acid/Core.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP, GADTs, DeriveDataTypeable, TypeFamilies,
-             FlexibleContexts, BangPatterns,
+             FlexibleContexts, BangPatterns, TypeApplications,
              DefaultSignatures, ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
 -- |
@@ -57,10 +57,11 @@ import Data.Monoid                        ((<>))
 import Data.ByteString.Lazy as Lazy       ( ByteString )
 import Data.ByteString.Lazy.Char8 as Lazy ( pack, unpack )
 
+import Data.Proxy                         ( Proxy(Proxy) )
 import Data.Serialize                     ( runPutLazy, runGetLazy )
 import Data.SafeCopy                      ( SafeCopy, safeGet, safePut )
 
-import Data.Typeable                      ( Typeable, TypeRep, typeRepTyCon, typeOf )
+import Data.Typeable                      ( Typeable, TypeRep, typeRepTyCon, typeOf, typeRep )
 import Unsafe.Coerce                      ( unsafeCoerce )
 
 #if MIN_VERSION_base(4,5,0)
@@ -170,18 +171,18 @@ mkCore methods initialValue
                     , coreMethods = mkMethodMap methods }
 
 -- | Mark Core as closed. Any subsequent use will throw an exception.
-closeCore :: Core st -> IO ()
+closeCore :: Typeable st => Core st -> IO ()
 closeCore core
     = closeCore' core (\_st -> return ())
 
 -- | Access the state and then mark the Core as closed. Any subsequent use
 --   will throw an exception.
-closeCore' :: Core st -> (st -> IO ()) -> IO ()
+closeCore' :: forall st. (Typeable st) => Core st -> (st -> IO ()) -> IO ()
 closeCore' core action
     = modifyMVar_ (coreState core) $ \st ->
       do action st
          return errorMsg
-    where errorMsg = error "Data.Acid.Core: Access failure: Core closed."
+    where errorMsg = error ("Data.Acid.Core: Access failure: Core closed. (" <> show (typeRep (Proxy @st)) <> ")")
 
 -- | Modify the state component. The resulting state is ensured to be in
 --   WHNF.

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -202,7 +202,7 @@ createLocalCheckpoint acidState
 -- | Save a snapshot to disk and close the AcidState as a single atomic
 --   action. This is useful when you want to make sure that no events
 --   are saved to disk after a checkpoint.
-createCheckpointAndClose :: (IsAcidic st, Typeable st) => AcidState st -> IO ()
+createCheckpointAndClose :: IsAcidic st => AcidState st -> IO ()
 createCheckpointAndClose abstract_state
     = do mvar <- newEmptyMVar
          closeCore' (localCore acidState) $ \st ->
@@ -430,7 +430,7 @@ checkpointRestoreError msg
 
 -- | Close an AcidState and associated logs.
 --   Any subsequent usage of the AcidState will throw an exception.
-closeLocalState :: LocalState st -> IO ()
+closeLocalState :: Typeable st => LocalState st -> IO ()
 closeLocalState acidState
     = do closeCore (localCore acidState)
          closeFileLog (localEvents acidState)

--- a/src/Data/Acid/Memory.hs
+++ b/src/Data/Acid/Memory.hs
@@ -113,7 +113,7 @@ createMemoryArchive acidState
 
 -- | Close an AcidState and associated logs.
 --   Any subsequent usage of the AcidState will throw an exception.
-closeMemoryState :: MemoryState st -> IO ()
+closeMemoryState :: Typeable st => MemoryState st -> IO ()
 closeMemoryState acidState
     = closeCore (localCore acidState)
 


### PR DESCRIPTION
 ...so the error message generated by closeCore can include the type of the AcidState.