### PR TITLE
v0.16.1.4: drop support for GHC 7

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250216
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250216",["github","acid-state.cabal"])
+# REGENDATA ("0.19.20250821",["github","acid-state.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,14 +32,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.1
+          - compiler: ghc-9.14.0.20250819
             compilerKind: ghc
-            compilerVersion: 9.12.1
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.10.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -47,9 +52,9 @@ jobs:
             compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -101,15 +106,30 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -131,7 +151,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -159,6 +179,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -207,9 +239,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_acid_state}" >> cabal.project
           echo "package acid-state" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package acid-state" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package acid-state" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(acid-state)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.16.1.4
+=========
+
+_Andreas Abel, 2025-08-27_
+
+- Drop support for GHC 7
+- Tested with GHC 8.2 - 9.14.1-alpha1
+
 0.16.1.3
 ========
 

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -1,6 +1,6 @@
+Cabal-version:       1.18
 Name:                acid-state
-Version:             0.16.1.3
-x-revision:          2
+Version:             0.16.1.4
 Synopsis:            Add ACID guarantees to any serializable Haskell data structure.
 Description:         Use regular Haskell data structures as your database and get stronger ACID guarantees than most RDBMS offer.
 Homepage:            https://github.com/acid-state/acid-state
@@ -10,7 +10,6 @@ Maintainer:          Lemmih <lemmih@gmail.com>
 -- Copyright:
 Category:            Database
 Build-type:          Simple
-Cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.14.1
@@ -30,8 +29,9 @@ tested-with:
   -- https://github.com/haskell/cabal/issues/10379
   -- GHC == 8.0.2
 
-Extra-source-files:
+Extra-doc-files:
         CHANGELOG.md
+Extra-source-files:
         test-state/OldStateTest1/*.log
         test-state/OldStateTest1/*.version
         test-state/OldStateTest2/*.log
@@ -49,40 +49,41 @@ flag skip-state-machine-test
   manual: False
 
 Library
-  Exposed-Modules:     Data.Acid,
-                       Data.Acid.Archive,
-                       Data.Acid.Common,
-                       Data.Acid.Local, Data.Acid.Memory,
-                       Data.Acid.Memory.Pure, Data.Acid.Remote,
-                       Data.Acid.Advanced,
-                       Data.Acid.Log, Data.Acid.CRC,
-                       Data.Acid.Abstract, Data.Acid.Core,
+  Exposed-Modules:     Data.Acid
+                       Data.Acid.Archive
+                       Data.Acid.Common
+                       Data.Acid.Local Data.Acid.Memory
+                       Data.Acid.Memory.Pure Data.Acid.Remote
+                       Data.Acid.Advanced
+                       Data.Acid.Log Data.Acid.CRC
+                       Data.Acid.Abstract Data.Acid.Core
                        Data.Acid.TemplateHaskell
                        Data.Acid.Repair
 
-  Other-modules:       Paths_acid_state,
+  Other-modules:       Paths_acid_state
                        FileIO
 
-  Build-depends:       array,
-                       base >= 4.9 && < 5,
-                       bytestring >= 0.10.2,
-                       cereal >= 0.4.1.0,
-                       containers,
-                       safecopy >= 0.6 && < 0.11,
-                       stm >= 2.4,
-                       directory,
-                       filelock,
-                       filepath,
-                       mtl,
-                       network < 3.3,
-                       network-bsd,
-                       template-haskell < 2.25,
-                       th-expand-syns
+  -- Lower bounds taken from GHC 8.0 / LTS 7.0
+  Build-depends:       array             >= 0.5.1.1
+                     , base              >= 4.9        && < 5
+                     , bytestring        >= 0.10.8.0
+                     , cereal            >= 0.5.3.0
+                     , containers        >= 0.5.7.1
+                     , safecopy          >= 0.6        && < 0.11
+                     , stm               >= 2.4
+                     , directory         >= 1.2.6.2
+                     , filelock          >= 0.1.0.1
+                     , filepath          >= 1.4.1.0
+                     , mtl               >= 2.2.1
+                     , network           >= 2.6.3.1    && < 3.3
+                     , network-bsd
+                     , template-haskell  >= 2.11.0.0   && < 2.25
+                     , th-expand-syns    >= 0.4.0.0
 
   if os(windows)
-     Build-depends:       Win32
+     Build-depends:       Win32          >= 2.3.1.1
   else
-     Build-depends:       unix
+     Build-depends:       unix           >= 2.7.2.0
 
   Hs-Source-Dirs:      src/
 
@@ -93,13 +94,12 @@ Library
 
   default-language:    Haskell2010
   GHC-Options:         -Wall
-                       -fno-warn-dodgy-imports
-                       -fno-warn-missing-signatures
-                       -fno-warn-name-shadowing
-                       -fno-warn-unused-do-bind
-                       -fno-warn-unused-matches
-  if impl(ghc >= 8.0)
-    ghc-options:       -Wcompat
+                       -Wcompat
+                       -Wno-dodgy-imports
+                       -Wno-missing-signatures
+                       -Wno-name-shadowing
+                       -Wno-unused-do-bind
+                       -Wno-unused-matches
 
 executable acid-state-repair
   hs-source-dirs: repair

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -64,7 +64,7 @@ Library
                        FileIO
 
   Build-depends:       array,
-                       base >= 4.7 && < 5,
+                       base >= 4.9 && < 5,
                        bytestring >= 0.10.2,
                        cereal >= 0.4.1.0,
                        containers,

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -13,10 +13,11 @@ Build-type:          Simple
 Cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.12.1
-  GHC == 9.10.1
+  GHC == 9.14.1
+  GHC == 9.12.2
+  GHC == 9.10.2
   GHC == 9.8.4
-  GHC == 9.6.6
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -75,7 +76,7 @@ Library
                        mtl,
                        network < 3.3,
                        network-bsd,
-                       template-haskell < 2.24,
+                       template-haskell < 2.25,
                        th-expand-syns
 
   if os(windows)
@@ -117,7 +118,6 @@ test-suite specs
                      , acid-state
                      , deepseq
                      , hspec
-                     , hspec-discover
                      , mtl
                      , safecopy
                      , template-haskell

--- a/examples/CheckpointCutsEvent.hs
+++ b/examples/CheckpointCutsEvent.hs
@@ -14,7 +14,6 @@ If you comment out the 'createArchive' line below, then the checkpoint
 files should contain 10 checkpoints each.
 
 -}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -27,7 +26,6 @@ import           Control.Monad.State  ( get, put )
 import           Data.Acid
 import           Data.List            ( sort )
 import           Data.SafeCopy
-import           Data.Typeable
 import           System.Directory
 import           System.Environment
 
@@ -35,7 +33,7 @@ import           System.Environment
 -- The Haskell structure that we want to encapsulate
 
 newtype Counter = Counter { unCounter :: Integer }
-    deriving (Show, Typeable)
+    deriving (Show)
 
 $(deriveSafeCopy 0 'base ''Counter)
 

--- a/examples/HelloDatabase.hs
+++ b/examples/HelloDatabase.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 

--- a/examples/HelloWorld.hs
+++ b/examples/HelloWorld.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -8,14 +7,13 @@ import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.Acid
 import           Data.SafeCopy
-import           Data.Typeable
 import           System.Environment
 
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
 
 data HelloWorldState = HelloWorldState String
-    deriving (Show, Typeable)
+    deriving (Show)
 
 $(deriveSafeCopy 0 'base ''HelloWorldState)
 

--- a/examples/HelloWorldNoTH.hs
+++ b/examples/HelloWorldNoTH.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -13,13 +12,11 @@ import           Control.Monad.State  (put)
 import           Data.SafeCopy
 import           System.Environment
 
-import           Data.Typeable
-
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
 
 data HelloWorldState = HelloWorldState String
-    deriving (Show, Typeable)
+    deriving (Show)
 
 instance SafeCopy HelloWorldState where
     putCopy (HelloWorldState state) = contain $ safePut state
@@ -57,8 +54,6 @@ main = do acid <- openLocalState (HelloWorldState "Hello world")
 data WriteState = WriteState String
 data QueryState = QueryState
 
-
-deriving instance Typeable WriteState
 instance SafeCopy WriteState where
     putCopy (WriteState st) = contain $ safePut st
     getCopy = contain $ liftM WriteState safeGet
@@ -67,7 +62,6 @@ instance Method WriteState where
     type MethodState WriteState = HelloWorldState
 instance UpdateEvent WriteState
 
-deriving instance Typeable QueryState
 instance SafeCopy QueryState where
     putCopy QueryState = contain $ return ()
     getCopy = contain $ return QueryState

--- a/examples/KeyValue.hs
+++ b/examples/KeyValue.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -15,8 +14,6 @@ import           System.Environment
 import           System.Exit
 import           System.IO
 
-import           Data.Typeable
-
 import qualified Data.Map             as Map
 
 ------------------------------------------------------
@@ -26,7 +23,6 @@ type Key = String
 type Value = String
 
 data KeyValue = KeyValue !(Map.Map Key Value)
-    deriving (Typeable)
 
 $(deriveSafeCopy 0 'base ''KeyValue)
 

--- a/examples/KeyValueNoTH.hs
+++ b/examples/KeyValueNoTH.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -15,8 +14,6 @@ import           Data.SafeCopy
 import           System.Environment
 import           System.IO
 
-import           Data.Typeable
-
 import qualified Data.Map             as Map
 
 ------------------------------------------------------
@@ -26,7 +23,6 @@ type Key = String
 type Value = String
 
 data KeyValue = KeyValue !(Map.Map Key Value)
-    deriving (Typeable)
 
 instance SafeCopy KeyValue where
     putCopy (KeyValue state) = contain $ safePut state
@@ -74,8 +70,6 @@ main = do acid <- openLocalState (KeyValue Map.empty)
 data InsertKey = InsertKey Key Value
 data LookupKey = LookupKey Key
 
-
-deriving instance Typeable InsertKey
 instance SafeCopy InsertKey where
     putCopy (InsertKey key value) = contain $ safePut key >> safePut value
     getCopy = contain $ InsertKey <$> safeGet <*> safeGet
@@ -84,7 +78,6 @@ instance Method InsertKey where
     type MethodState InsertKey = KeyValue
 instance UpdateEvent InsertKey
 
-deriving instance Typeable LookupKey
 instance SafeCopy LookupKey where
     putCopy (LookupKey key) = contain $ safePut key
     getCopy = contain $ LookupKey <$> safeGet

--- a/examples/MonadStateConstraint.hs
+++ b/examples/MonadStateConstraint.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
@@ -9,14 +8,13 @@ import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.Acid
 import           Data.SafeCopy
-import           Data.Typeable
 import           System.Environment
 
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
 
 data HelloWorldState = HelloWorldState String
-    deriving (Show, Typeable)
+    deriving (Show)
 
 $(deriveSafeCopy 0 'base ''HelloWorldState)
 

--- a/examples/ParameterisedState.hs
+++ b/examples/ParameterisedState.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -28,10 +27,6 @@ $(deriveSafeCopy 0 'base ''Entry)
 
 newtype Store k = Store { store :: Map.Map k (Entry k) }
     deriving (Eq, Generic)
-
-#if __GLASGOW_HASKELL__ <= 708
-deriving instance Typeable1 Store
-#endif
 
 instance (Ord k, Serialize k, SafeCopy k, Typeable k) => SafeCopy (Store k)
 instance (Ord k, Serialize k) => Serialize (Store k)

--- a/examples/Proxy.hs
+++ b/examples/Proxy.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -15,13 +14,10 @@ import           Data.SafeCopy
 import           System.Environment
 import           System.IO
 
-import           Data.Typeable
-
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
 
 data ProxyStressState = StressState !Int
-    deriving (Typeable)
 
 $(deriveSafeCopy 0 'base ''ProxyStressState)
 

--- a/examples/RemoteCommon.hs
+++ b/examples/RemoteCommon.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -8,12 +7,11 @@ import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.Acid
 import           Data.SafeCopy
-import           Data.Typeable
 
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
 
-data StressState = StressState !Int deriving (Typeable)
+data StressState = StressState !Int
 
 $(deriveSafeCopy 0 'base ''StressState)
 

--- a/examples/SlowCheckpoint.hs
+++ b/examples/SlowCheckpoint.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 

--- a/examples/StressTest.hs
+++ b/examples/StressTest.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -13,13 +12,10 @@ import           Data.SafeCopy
 import           System.Environment
 import           System.IO
 
-import           Data.Typeable
-
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
 
 data StressState = StressState !Int
-    deriving (Typeable)
 
 $(deriveSafeCopy 0 'base ''StressState)
 

--- a/examples/StressTestNoTH.hs
+++ b/examples/StressTestNoTH.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -14,13 +13,10 @@ import           Data.SafeCopy
 import           System.Environment
 import           System.IO
 
-import           Data.Typeable
-
 ------------------------------------------------------
 -- The Haskell structure that we want to encapsulate
 
 data StressState = StressState !Int
-    deriving (Typeable)
 
 instance SafeCopy StressState where
     putCopy (StressState state) = contain $ safePut state
@@ -66,7 +62,6 @@ main = do args <- getArgs
 data PokeState = PokeState
 data QueryState = QueryState
 
-deriving instance Typeable PokeState
 instance SafeCopy PokeState where
     putCopy PokeState = contain $ return ()
     getCopy = contain $ return PokeState
@@ -75,7 +70,6 @@ instance Method PokeState where
     type MethodState PokeState = StressState
 instance UpdateEvent PokeState
 
-deriving instance Typeable QueryState
 instance SafeCopy QueryState where
     putCopy QueryState = contain $ return ()
     getCopy = contain $ return QueryState

--- a/examples/errors/Exceptions.hs
+++ b/examples/errors/Exceptions.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -17,8 +16,6 @@ import           Data.SafeCopy
 import           System.Directory
 import           System.Environment
 
-import           Data.Typeable
-
 import           Control.Exception
 import           Prelude             hiding (catch)
 
@@ -26,7 +23,7 @@ import           Prelude             hiding (catch)
 -- The Haskell structure that we want to encapsulate
 
 data MyState = MyState Integer
-    deriving (Show, Typeable)
+    deriving (Show)
 
 $(deriveSafeCopy 0 'base ''MyState)
 

--- a/examples/errors/Exceptions.hs
+++ b/examples/errors/Exceptions.hs
@@ -7,9 +7,6 @@ module Exceptions (main, test) where
 import           Data.Acid
 import           Data.Acid.Local     (createCheckpointAndClose)
 
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-#endif
 import           Control.Monad
 import           Control.Monad.State ( get, put )
 import           Data.SafeCopy

--- a/examples/errors/RemoveEvent.hs
+++ b/examples/errors/RemoveEvent.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -11,8 +10,6 @@ import           Data.SafeCopy
 import           System.Directory
 import           System.Environment
 import           Data.List (isSuffixOf)
-
-import           Data.Typeable
 
 import           Control.Exception
 import           Prelude             hiding (catch)

--- a/src/Data/Acid/Common.hs
+++ b/src/Data/Acid/Common.hs
@@ -17,10 +17,6 @@ import Data.Acid.Core
 import Control.Monad
 import Control.Monad.State   (MonadState, get, State)
 import Control.Monad.Reader  (MonadReader, Reader, runReader)
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
-
 
 class IsAcidic st where
     acidEvents :: [Event st]

--- a/src/Data/Acid/Core.hs
+++ b/src/Data/Acid/Core.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, GADTs, DeriveDataTypeable, TypeFamilies,
+{-# LANGUAGE CPP, GADTs, TypeFamilies,
              FlexibleContexts, BangPatterns,
              DefaultSignatures, ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
@@ -60,16 +60,8 @@ import Data.ByteString.Lazy.Char8 as Lazy ( pack, unpack )
 import Data.Serialize                     ( runPutLazy, runGetLazy )
 import Data.SafeCopy                      ( SafeCopy, safeGet, safePut )
 
-import Data.Typeable                      ( Typeable, TypeRep, typeRepTyCon, typeOf )
+import Data.Typeable                      ( Typeable, TypeRep, typeRepTyCon, typeOf, tyConModule )
 import Unsafe.Coerce                      ( unsafeCoerce )
-
-#if MIN_VERSION_base(4,5,0)
-import Data.Typeable                      ( tyConModule )
-#else
-import Data.Typeable.Internal             ( tyConModule )
-#endif
-
-#if MIN_VERSION_base(4,4,0)
 
 -- in base >= 4.4 the Show instance for TypeRep no longer provides a
 -- fully qualified name. But we have old data around that expects the
@@ -79,14 +71,6 @@ import Data.Typeable.Internal             ( tyConModule )
 showQualifiedTypeRep :: TypeRep -> String
 showQualifiedTypeRep tr = tyConModule con ++ "." ++ show tr
   where con = typeRepTyCon tr
-
-#else
-
-showQualifiedTypeRep :: TypeRep -> String
-showQualifiedTypeRep tr = show tr
-
-#endif
-
 
 -- | Interface for (de)serialising values of type @a@.
 --

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -41,9 +41,6 @@ import Control.Concurrent             ( newEmptyMVar, putMVar, takeMVar, MVar )
 import Control.Exception              ( onException, evaluate, Exception, throwIO )
 import Control.Monad.State            ( runState )
 import Control.Monad                  ( join )
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative            ( (<$>), (<*>) )
-#endif
 import Data.ByteString.Lazy           ( ByteString )
 import qualified Data.ByteString.Lazy as Lazy ( length )
 

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, BangPatterns, CPP #-}
+{-# LANGUAGE BangPatterns, CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Acid.Local
@@ -76,9 +76,9 @@ data LocalState st
                  , localEvents      :: FileLog (Tagged ByteString)
                  , localCheckpoints :: FileLog (Checkpoint st)
                  , localLock        :: FileLock
-                 } deriving (Typeable)
+                 }
 
-newtype StateIsLocked = StateIsLocked FilePath deriving (Show, Typeable)
+newtype StateIsLocked = StateIsLocked FilePath deriving (Show)
 
 instance Exception StateIsLocked
 

--- a/src/Data/Acid/Memory.hs
+++ b/src/Data/Acid/Memory.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, BangPatterns #-}
+{-# LANGUAGE BangPatterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Acid.Memory
@@ -22,7 +22,6 @@ import Data.Acid.Abstract
 import Control.Concurrent             ( newEmptyMVar, putMVar, MVar )
 import Control.Monad.State            ( runState )
 import Data.ByteString.Lazy           ( ByteString )
-import Data.Typeable                  ( Typeable )
 import Data.IORef                     ( IORef, newIORef, readIORef, writeIORef )
 
 
@@ -42,7 +41,7 @@ import Data.IORef                     ( IORef, newIORef, readIORef, writeIORef )
 data MemoryState st
     = MemoryState { localCore    :: Core st
                   , localCopy    :: IORef st
-                  } deriving (Typeable)
+                  }
 
 -- | Create an 'AcidState' given an initial value.  The state is kept only in
 -- memory, so it is not durable.

--- a/src/Data/Acid/Memory/Pure.hs
+++ b/src/Data/Acid/Memory/Pure.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, BangPatterns #-}
+{-# LANGUAGE BangPatterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Acid.Memory.Pure

--- a/src/Data/Acid/Remote.hs
+++ b/src/Data/Acid/Remote.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DeriveDataTypeable, RankNTypes, RecordWildCards, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, RankNTypes, RecordWildCards, ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
 {- |
  Module      :  Data.Acid.Remote
@@ -122,7 +122,6 @@ import qualified Data.ByteString.Lazy                as Lazy
 import Data.IORef                                    ( newIORef, readIORef, writeIORef )
 import Data.Serialize
 import Data.Set                                      ( Set, member )
-import Data.Typeable                                 ( Typeable )
 import GHC.IO.Exception                              ( IOErrorType(..) )
 import Network.BSD                                   ( PortNumber, getProtocolNumber, getHostByName, hostAddress )
 import Network.Socket
@@ -150,7 +149,7 @@ data AcidRemoteException
     | AcidStateClosed
     | SerializeError String
     | AuthenticationError String
-      deriving (Eq, Show, Typeable)
+      deriving (Eq, Show)
 instance Exception AcidRemoteException
 
 -- | create a 'CommChannel' from a 'Handle'. The 'Handle' should be
@@ -380,7 +379,6 @@ process CommChannel{..} acidState
                                 writeChan chan (return Acknowledgement)
 
 data RemoteState st = RemoteState (Command -> IO (MVar Response)) (IO ())
-                    deriving (Typeable)
 
 {- | Connect to an acid-state server which is sharing an 'AcidState'. -}
 openRemoteState :: IsAcidic st =>

--- a/src/Data/Acid/Remote.hs
+++ b/src/Data/Acid/Remote.hs
@@ -96,9 +96,6 @@ module Data.Acid.Remote
     ) where
 
 import Prelude                                hiding ( catch )
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 import Control.Concurrent.STM                        ( atomically )
 import Control.Concurrent.STM.TMVar                  ( newEmptyTMVar, readTMVar, takeTMVar, tryTakeTMVar, putTMVar )
 import Control.Concurrent.STM.TQueue

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -328,18 +328,11 @@ makeEventHandler ss eventName eventType
                       , pprint stateType
                       ]
 
---data MyUpdateEvent = MyUpdateEvent Arg1 Arg2
---  deriving (Typeable)
+-- data MyUpdateEvent = MyUpdateEvent Arg1 Arg2
 makeEventDataType :: Name -> Type -> DecQ
 makeEventDataType eventName eventType
     = do let con = normalC eventStructName [ strictType notStrict (return arg) | arg <- args ]
-#if MIN_VERSION_template_haskell(2,12,0)
-             cxt = [derivClause Nothing [conT ''Typeable]]
-#elif MIN_VERSION_template_haskell(2,11,0)
-             cxt = mapM conT [''Typeable]
-#else
-             cxt = [''Typeable]
-#endif
+             cxt = []
          case args of
 #if MIN_VERSION_template_haskell(2,21,0)
           [_] -> newtypeD (return []) eventStructName (map (BndrReq <$) tyvars) Nothing con cxt

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -17,9 +17,6 @@ import Data.Char
 #if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
 #endif
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 import Control.Monad
 import Control.Monad.State (MonadState)
 import Control.Monad.Reader (MonadReader)

--- a/test/Data/Acid/KeyValueStateMachine.hs
+++ b/test/Data/Acid/KeyValueStateMachine.hs
@@ -17,7 +17,6 @@ import           Data.Acid
 import           Data.Acid.StateMachineTest
 import           Data.SafeCopy
 import qualified Data.Map as Map
-import           Data.Typeable
 import           GHC.Generics
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -28,7 +27,7 @@ type Key = Int
 type Value = String
 
 data KeyValue = KeyValue !(Map.Map Key Value)
-    deriving (Eq, Show, Typeable)
+    deriving (Eq, Show)
 
 $(deriveSafeCopy 0 'base ''KeyValue)
 

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -11,7 +11,6 @@ module Data.Acid.TemplateHaskellSpec where
 import Test.Hspec hiding (context)
 
 import Data.SafeCopy (SafeCopy)
-import Data.Typeable (Typeable)
 import Control.DeepSeq (force)
 import Control.Exception (evaluate)
 import Language.Haskell.TH

--- a/test/Data/Acid/TemplateHaskellSpec.hs
+++ b/test/Data/Acid/TemplateHaskellSpec.hs
@@ -104,15 +104,10 @@ spec = do
                 `shouldBe` TypeAnalysis
                     { tyvars = []
                     , context =
-#if MIN_VERSION_template_haskell(2,10,0)
                         [ ConT ''MonadReader
                             `AppT` ConT ''Int
                             `AppT` VarT m
                         ]
-#else
-                        [ ClassP ''MonadReader [ConT ''Int, VarT m]
-                        ]
-#endif
                     , argumentTypes = [ConT ''Int]
                     , stateType = ConT ''Int
                     , resultType = VarT m `AppT` TupleT 0
@@ -154,21 +149,13 @@ spec = do
 
             eventCxts stateType binders name eventType
                 `shouldBe`
-#if MIN_VERSION_template_haskell(2,10,0)
                     [ConT ''Ord `AppT` VarT x]
-#else
-                    [ClassP ''Ord [VarT x]]
-#endif
 
         it "can rename a polymorphic state" $ do
             eventType <- runQ [t| forall r m. (MonadReader r m, Ord r) => Int -> m Char |]
             eventCxts stateType binders name eventType
                 `shouldBe`
-#if MIN_VERSION_template_haskell(2,10,0)
                     [ConT ''Ord `AppT` ConT ''Char]
-#else
-                    [ClassP ''Ord [ConT ''Char]]
-#endif
 
 
 quoteShouldBe :: (Eq a, Show a) => Q a -> Q [a] -> Expectation


### PR DESCRIPTION
- **Bump Haskell CI to GHC 9.14 alpha1**
  

- **Remove `deriving Typeable` obsolete since GHC 7.10**
  

- **Remove conditionals for GHC 7 (base < 4.9)**
  

- **Remove conditionals for template-haskell<2.11 (GHC 7)**
  

- **v0.16.1.4: drop support for GHC 7**

Candidate: https://hackage.haskell.org/package/acid-state-0.16.1.4/candidate
  